### PR TITLE
Set the test validator address to 127.0.0.1

### DIFF
--- a/templates/anchor/Anchor.toml
+++ b/templates/anchor/Anchor.toml
@@ -12,3 +12,6 @@ wallet = "{{ solana_wallet }}"
 
 [scripts]
 test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
+
+[test.validator]
+bind_address = "127.0.0.1"


### PR DESCRIPTION
`anchor run test` was failing, because it was trying to connect to `::1`(IPv6) instead of `127.0.0.1` (IPv4). `solana-test-validator` uses IPv4 by default. Setting the bind address to `127.0.0.1` in `Anchor.toml` fixes the issue.