### PR TITLE
feat: block local-publish if local-registry is not running

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "format": "yarn nx format:write --all",
     "lint": "yarn nx run-many --target=lint --all",
     "local-registry": "nx run @solana-developers/source:local-registry",
+    "prelocal-publish": "ts-node tools/scripts/ensure-local-registry.ts",
     "local-publish": "nx run-many --targets publish --tag local --ver ",
     "test": "yarn nx run-many --target=test --all",
     "sync-schemas": "ts-node ./tools/scripts/sync-schemas.ts",

--- a/tools/scripts/ensure-local-registry.ts
+++ b/tools/scripts/ensure-local-registry.ts
@@ -1,0 +1,9 @@
+import { execSync } from 'node:child_process'
+
+const registry = execSync('npm config get registry').toString().trim()
+
+if (!registry.startsWith('http://localhost:')) {
+  console.error(`Expected npm registry to be http://localhost:*, but was ${registry}`)
+  console.error('Please run `yarn run local-registry` in another terminal window.')
+  process.exit(1)
+}


### PR DESCRIPTION
This adds a check to prevent pushing local tags to any registry other than localhost.