### PR TITLE
fix: conditionally add LICENSE and README.md to workspace root

### DIFF
--- a/packages/preset-next/src/generators/next-application/next-application-generator.ts
+++ b/packages/preset-next/src/generators/next-application/next-application-generator.ts
@@ -1,19 +1,12 @@
-import {
-  addDependenciesToPackageJson,
-  formatFiles,
-  getProjects,
-  installPackagesTask,
-  Tree,
-  updateJson,
-} from '@nx/devkit'
+import { addDependenciesToPackageJson, getProjects, installPackagesTask, Tree } from '@nx/devkit'
 import { getNpmScope } from '@nx/js/src/utils/package-json/get-npm-scope'
 import { anchorApplicationGenerator } from '@solana-developers/preset-anchor'
-import { applicationCleanup, commonTemplateGenerator, packageVersion } from '@solana-developers/preset-common'
+import { applicationCleanup, packageVersion } from '@solana-developers/preset-common'
 import {
   applicationTailwindConfig,
   features,
+  generateReactCommonFiles,
   reactApplicationDependencies,
-  reactApplicationRunScripts,
   ReactFeature,
   reactFeatureGenerator,
   reactTemplateGenerator,
@@ -156,44 +149,7 @@ export default function Page() {
   },`
   tree.write(nextConfigPath, nextConfig.replace(needle, `${needle}\n${snippet}`))
 
-  updateJson(tree, 'package.json', (json) => {
-    json.scripts = {
-      ...json.scripts,
-      ...reactApplicationRunScripts({
-        anchor: options.anchor,
-        anchorName: options.anchorName,
-        webName: options.webName,
-      }),
-    }
-    return json
-  })
-
-  // Generate the readme files
-  await commonTemplateGenerator(tree, {
-    name: options.webName,
-    npmScope,
-    template: 'readme',
-    anchor: options.anchor,
-    anchorName: options.anchorName,
-    webName: options.webName,
-    directory: '.',
-  })
-
-  // Generate the license files
-  await commonTemplateGenerator(tree, {
-    name: options.webName,
-    npmScope,
-    template: 'license',
-    anchor: options.anchor,
-    anchorName: options.anchorName,
-    webName: options.webName,
-    directory: '.',
-  })
-
-  // Format the files.
-  if (!options.skipFormat) {
-    await formatFiles(tree)
-  }
+  await generateReactCommonFiles(tree, options, npmScope)
 
   // Install the packages on exit.
   return () => {

--- a/packages/preset-react/src/generators/react-application/react-application-generator.ts
+++ b/packages/preset-react/src/generators/react-application/react-application-generator.ts
@@ -1,19 +1,19 @@
-import { formatFiles, getProjects, installPackagesTask, Tree, updateJson } from '@nx/devkit'
+import { getProjects, installPackagesTask, Tree } from '@nx/devkit'
 import { getNpmScope } from '@nx/js/src/utils/package-json/get-npm-scope'
 import { anchorApplicationGenerator } from '@solana-developers/preset-anchor'
-import { applicationCleanup, commonTemplateGenerator } from '@solana-developers/preset-common'
+import { applicationCleanup } from '@solana-developers/preset-common'
 import { join } from 'path'
 import {
   applicationTailwindConfig,
   generateReactApplication,
+  generateReactCommonFiles,
   NormalizedReactApplicationSchema,
   normalizeReactApplicationSchema,
   reactApplicationDependencies,
-  reactApplicationRunScripts,
   walletAdapterDependencies,
 } from '../../utils'
-import { reactTemplateGenerator } from '../react-template/react-template-generator'
 import { features, ReactFeature, reactFeatureGenerator } from '../react-feature'
+import { reactTemplateGenerator } from '../react-template/react-template-generator'
 import { ReactApplicationSchema } from './react-application-schema'
 
 export async function reactApplicationGenerator(tree: Tree, rawOptions: ReactApplicationSchema) {
@@ -88,45 +88,7 @@ export async function reactApplicationGenerator(tree: Tree, rawOptions: ReactApp
       feature,
     })
   }
-
-  updateJson(tree, 'package.json', (json) => {
-    json.scripts = {
-      ...json.scripts,
-      ...reactApplicationRunScripts({
-        anchor: options.anchor,
-        anchorName: options.anchorName,
-        webName: options.webName,
-      }),
-    }
-    return json
-  })
-
-  // Generate the readme files
-  await commonTemplateGenerator(tree, {
-    name: options.webName,
-    npmScope,
-    template: 'readme',
-    anchor: options.anchor,
-    anchorName: options.anchorName,
-    webName: options.webName,
-    directory: '.',
-  })
-
-  // Generate the license files
-  await commonTemplateGenerator(tree, {
-    name: options.webName,
-    npmScope,
-    template: 'license',
-    anchor: options.anchor,
-    anchorName: options.anchorName,
-    webName: options.webName,
-    directory: '.',
-  })
-
-  // Format the files.
-  if (!options.skipFormat) {
-    await formatFiles(tree)
-  }
+  await generateReactCommonFiles(tree, options, npmScope)
 
   // Install the packages on exit.
   return () => {

--- a/packages/preset-react/src/utils/generate-react-common-files.ts
+++ b/packages/preset-react/src/utils/generate-react-common-files.ts
@@ -1,0 +1,53 @@
+import { formatFiles, Tree, updateJson } from '@nx/devkit'
+import { commonTemplateGenerator } from '@solana-developers/preset-common'
+import { NormalizedReactApplicationSchema } from './normalize-react-application-schema'
+import { reactApplicationRunScripts } from './react-application-run-scripts'
+
+export async function generateReactCommonFiles(
+  tree: Tree,
+  options: NormalizedReactApplicationSchema,
+  npmScope: string,
+) {
+  updateJson(tree, 'package.json', (json) => {
+    json.scripts = {
+      ...json.scripts,
+      ...reactApplicationRunScripts({
+        anchor: options.anchor,
+        anchorName: options.anchorName,
+        webName: options.webName,
+      }),
+    }
+    return json
+  })
+
+  if (!tree.exists('README.md')) {
+    // Generate the readme files
+    await commonTemplateGenerator(tree, {
+      name: options.webName,
+      npmScope,
+      template: 'readme',
+      anchor: options.anchor,
+      anchorName: options.anchorName,
+      webName: options.webName,
+      directory: '.',
+    })
+  }
+
+  if (!tree.exists('LICENSE') && !tree.exists('LICENSE.md')) {
+    // Generate the license files
+    await commonTemplateGenerator(tree, {
+      name: options.webName,
+      npmScope,
+      template: 'license',
+      anchor: options.anchor,
+      anchorName: options.anchorName,
+      webName: options.webName,
+      directory: '.',
+    })
+  }
+
+  // Format the files.
+  if (!options.skipFormat) {
+    await formatFiles(tree)
+  }
+}

--- a/packages/preset-react/src/utils/index.ts
+++ b/packages/preset-react/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './application-tailwind-config'
+export * from './generate-react-common-files'
 export * from './generate-react-application'
 export * from './get-ui-dependencies'
 export * from './normalize-react-application-schema'


### PR DESCRIPTION
This patch adds a check before creating the `LICENSE` or `README.md`.

This is useful when running our generators in a different Nx workspace that might already have these files.