### PR TITLE
added maintainers doc and `dist-tag` NX target

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,71 @@
+# Maintaining create-solana-dapp
+
+The document has a collection of information for the maintainers of this mono repo and the child packages contained
+within.
+
+## Publishing new versions
+
+Normally, all the packages included within this repo are published together and should use the same specific version
+number between all packages. This includes the primary `create-solana-dapp` CLI tool and the
+`@solana-developers/preset-*` child packages. As such, all these packages are collectively referred to as
+`create-solana-dapp` or `CSD` for short.
+
+> Note: Your NPM cli must be logged into the NPM registry and have the correct permissions to publish a new version.
+
+### `next` tag
+
+The `next` tag is considered the beta/testing version of the `create-solana-dapp` tool, and the specific version will
+normally include such a `beta` flag in it:
+
+```shell
+npx nx run-many --targets publish --tag next --ver x.x.x-beta.x
+```
+
+This will allow anyone to use the current beta/next version of the CLI using the following command:
+
+```shell
+npx create-solana-dapp@next
+```
+
+### `latest` tag
+
+The `latest` tag is considered the production/stable version of the `create-solana-dapp` tool. To publish to the
+`latest` tag:
+
+```shell
+npx nx run-many --targets publish --tag latest --ver x.x.x
+```
+
+This will allow anyone to use the current production/stable version of the CLI using the following command:
+
+```shell
+npx create-solana-dapp@latest
+```
+
+### Set a tagged version to a specific published version
+
+In the case we need to set the specific version associated with `create-solana-dapp` and child packages (e.g. rolling
+back the `latest` tag to a previous version) you can run the `dist-tag` target via NX on any of the CSD packages in this
+monorepo.
+
+#### All child packages
+
+To force all child packages to have a specific tag with a specific published version:
+
+```shell
+npx nx run-many --targets dist-tag --tag next --ver x.x.x
+```
+
+#### Single child package
+
+To set a specific child package's tag to be a specific published version:
+
+```shell
+# `next` tag
+npx nx run solana-dev:dist-tag --tag next --ver x.x.x
+```
+
+```shell
+# `latest` tag
+npx nx run solana-dev:dist-tag --tag latest --ver x.x.x
+```

--- a/packages/create-solana-dapp/project.json
+++ b/packages/create-solana-dapp/project.json
@@ -18,6 +18,9 @@
       "command": "node tools/scripts/publish.mjs create-solana-dapp {args.ver} {args.tag}",
       "dependsOn": ["build"]
     },
+    "dist-tag": {
+      "command": "npm dist-tag add create-solana-dapp@{args.ver} {args.tag}"
+    },
     "lint": {
       "executor": "@nx/eslint:lint",
       "outputs": ["{options.outputFile}"]

--- a/packages/preset-anchor/project.json
+++ b/packages/preset-anchor/project.json
@@ -40,6 +40,9 @@
       "command": "node tools/scripts/publish.mjs preset-anchor {args.ver} {args.tag}",
       "dependsOn": ["build"]
     },
+    "dist-tag": {
+      "command": "npm dist-tag add @solana-developers/preset-anchor@{args.ver} {args.tag}"
+    },
     "lint": {
       "executor": "@nx/linter:eslint",
       "outputs": ["{options.outputFile}"],

--- a/packages/preset-common/project.json
+++ b/packages/preset-common/project.json
@@ -40,6 +40,9 @@
       "command": "node tools/scripts/publish.mjs preset-common {args.ver} {args.tag}",
       "dependsOn": ["build"]
     },
+    "dist-tag": {
+      "command": "npm dist-tag add @solana-developers/preset-common@{args.ver} {args.tag}"
+    },
     "lint": {
       "executor": "@nx/eslint:lint",
       "outputs": ["{options.outputFile}"]

--- a/packages/preset-next/project.json
+++ b/packages/preset-next/project.json
@@ -40,6 +40,9 @@
       "command": "node tools/scripts/publish.mjs preset-next {args.ver} {args.tag}",
       "dependsOn": ["build"]
     },
+    "dist-tag": {
+      "command": "npm dist-tag add @solana-developers/preset-next@{args.ver} {args.tag}"
+    },
     "lint": {
       "executor": "@nx/eslint:lint",
       "outputs": ["{options.outputFile}"]

--- a/packages/preset-react/project.json
+++ b/packages/preset-react/project.json
@@ -40,6 +40,9 @@
       "command": "node tools/scripts/publish.mjs preset-react {args.ver} {args.tag}",
       "dependsOn": ["build"]
     },
+    "dist-tag": {
+      "command": "npm dist-tag add @solana-developers/preset-react@{args.ver} {args.tag}"
+    },
     "lint": {
       "executor": "@nx/eslint:lint",
       "outputs": ["{options.outputFile}"]

--- a/packages/solana-dev/project.json
+++ b/packages/solana-dev/project.json
@@ -18,6 +18,9 @@
       "command": "node tools/scripts/publish.mjs solana-dev {args.ver} {args.tag}",
       "dependsOn": ["build"]
     },
+    "dist-tag": {
+      "command": "npm dist-tag add solana-dev@{args.ver} {args.tag}"
+    },
     "lint": {
       "executor": "@nx/eslint:lint",
       "outputs": ["{options.outputFile}"]


### PR DESCRIPTION
Added a maintainers document with some assorted details about publishing.

Also added a `dist-tag` target on each of the generator's published packages. This target will allow us to easily force set a specific NPM `tag` to a specific `version` for all the packages (e.g. if we need to rollback the `latest` tag to a previous version)

Example:

```
npx nx run-many --targets dist-tag --tag next --ver 2.2.0
```