### PR TITLE
fix: don't show anchor name if program option 'none' is selected

### DIFF
--- a/packages/create-solana-dapp/lib/get-prompts.ts
+++ b/packages/create-solana-dapp/lib/get-prompts.ts
@@ -61,9 +61,11 @@ export function getPrompts({
         })
       },
       anchorProgram: ({ results }) => {
-        const anchorProgram = options.anchorProgram.length ? options.anchorProgram : results.name ?? 'my-program'
-        log.success(`Anchor program name: ${anchorProgram}`)
-        return Promise.resolve(anchorProgram)
+        if (options.anchor) {
+          const anchorProgram = options.anchorProgram.length ? options.anchorProgram : results.name ?? 'my-program'
+          log.success(`Anchor program name: ${anchorProgram}`)
+          return Promise.resolve(anchorProgram)
+        }
       },
     },
     {


### PR DESCRIPTION
Fixes #51 