### PR TITLE
fix: only use the semver version number without a suffix

### DIFF
--- a/src/utils/get-version.ts
+++ b/src/utils/get-version.ts
@@ -9,16 +9,16 @@ export function getVersion(command: string, regex: RegExp): string | undefined {
 }
 
 export function getVersionAnchor(): string | undefined {
-  return getVersion('anchor --version', /anchor-cli (.*)/)
+  return getVersion('anchor --version', /anchor-cli (\d+\.\d+\.\d+)/)
 }
 
 export function getVersionSolana(): string | undefined {
-  return getVersion('solana --version', /solana-cli (.*)/)
+  return getVersion('solana --version', /solana-cli (\d+\.\d+\.\d+)/)
 }
 
 export function getVersionRust(): string | undefined {
-  return getVersion('rustc --version', /rustc (.*)/)
+  return getVersion('rustc --version', /rustc (\d+\.\d+\.\d+)/)
 }
 export function getVersionAvm(): string | undefined {
-  return getVersion('avm --version', /avm (.*)/)
+  return getVersion('avm --version', /avm (\d+\.\d+\.\d+)/)
 }

--- a/src/utils/vendor/package-manager.ts
+++ b/src/utils/vendor/package-manager.ts
@@ -26,7 +26,6 @@ export function detectInvokedPackageManager(): PackageManager {
 
   for (const pkgManager of packageManagers) {
     if (invoker.path.includes(pkgManager)) {
-      console.log(`Found ${pkgManager}`)
       detectedPackageManager = pkgManager
       break
     }


### PR DESCRIPTION
Before
```
$ node ./dist/bin/index.cjs --list-versions
Locally installed versions:
  Anchor: 0.30.1
  AVM   : 0.30.0
  Rust  : 1.77.2 (25ef9e3d8 2024-04-09)
  Solana: 1.18.9 (src:9a7dd9ca; feat:3469865029, client:SolanaLabs)
```

After
```
$ node ./dist/bin/index.cjs --list-versions
Locally installed versions:
  Anchor: 0.30.1
  AVM   : 0.30.0
  Rust  : 1.77.2
  Solana: 1.18.9
```