### PR TITLE
Syntax highlight with jsonc in the README so that GitHub doesn't show it ugly

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Template authors can add an init script to the `package.json` file to help set u
 Use this script to return instructions to the user, check the `anchor` and `solana` versions, and replace text and files
 in the project.
 
-```json
+```jsonc
 {
   "name": "your-template",
   "create-solana-dapp": {

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ in the project.
     "instructions": [
       "Run Anchor commands:",
       // Adding a '+' will make the line bold and '{pm}' is replaced with the package manager
-      "+{pm} run anchor build | test | localnet | deploy"
+      "+{pm} run anchor build | test | localnet | deploy",
     ],
     // Rename is a map of terms to rename
     "rename": {
@@ -58,15 +58,15 @@ in the project.
         // With the name of the project
         "to": "{{name}}",
         // In the following paths
-        "paths": ["anchor", "src"]
-      }
+        "paths": ["anchor", "src"],
+      },
     },
     // Check versions and give a warning if it's not installed or the version is lower
     "versions": {
       "anchor": "0.30.1",
-      "solana": "1.18.0"
-    }
-  }
+      "solana": "1.18.0",
+    },
+  },
 }
 ```
 


### PR DESCRIPTION
Fixes this:

<img width="832" alt="image" src="https://github.com/user-attachments/assets/3c676f57-2596-416c-afea-95f6b95801e0">
