### PR TITLE
feat: add support for a template registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "unbuild": "^3.3.1",
     "vitest": "^3.0.5"
   },
-  "packageManager": "pnpm@10.2.1",
+  "packageManager": "pnpm@10.5.1+sha512.c424c076bd25c1a5b188c37bb1ca56cc1e136fbf530d98bcb3289982a08fd25527b8c9c4ec113be5e3393c39af04521dd647bcf1d0801eaf8ac6a7b14da313af",
   "dependencies": {
     "@clack/prompts": "^0.7.0",
     "commander": "^13.1.0",

--- a/src/registry/registry.ts
+++ b/src/registry/registry.ts
@@ -1,0 +1,14 @@
+import { Registry, validateRegistry } from './validate-registry'
+
+export const defaultIndex = `https://raw.githubusercontent.com/solana-developers/solana-templates/refs/heads/main/index.json`
+export const solanaTemplatesIndex = process.env.SOLANA_TEMPLATES_INDEX ?? defaultIndex
+
+export async function getRegistry(): Promise<Registry> {
+  const result = await fetch(solanaTemplatesIndex)
+
+  if (!result.ok) {
+    throw new Error(`Failed to fetch registry index file: ${solanaTemplatesIndex}`)
+  }
+
+  return validateRegistry(await result.json())
+}

--- a/src/registry/validate-registry.ts
+++ b/src/registry/validate-registry.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod'
+
+// Template schema
+const registryTemplateSchema = z.object({
+  name: z.string(),
+  description: z.string(),
+  repository: z.string(),
+})
+
+// Group schema
+const registryGroupSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string(),
+  templates: z.array(registryTemplateSchema),
+})
+
+// Section schema (default/legacy)
+const registrySectionSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  groups: z.array(registryGroupSchema),
+})
+
+// Main schema: requires 'default' and allows additional sections
+const registrySchema = z
+  .object({
+    default: registrySectionSchema, // 'default' is required
+  })
+  .catchall(registrySectionSchema) // Any other key is optional and must match registrySectionSchema
+
+// Type inference
+export type Registry = z.infer<typeof registrySchema>
+export type RegistrySection = z.infer<typeof registrySectionSchema>
+export type RegistryGroup = z.infer<typeof registryGroupSchema>
+export type RegistryTemplate = z.infer<typeof registryTemplateSchema>
+
+export async function validateRegistry(resultJson: unknown): Promise<Registry> {
+  return registrySchema.parse(resultJson)
+}

--- a/src/utils/get-args.ts
+++ b/src/utils/get-args.ts
@@ -1,5 +1,8 @@
 import { intro, log, outro } from '@clack/prompts'
 import { program } from 'commander'
+import pico from 'picocolors'
+import { getRegistry } from '../registry/registry'
+import { Registry, RegistrySection } from '../registry/validate-registry'
 import { findTemplate, listTemplates, Template } from '../templates/templates'
 import { AppInfo } from './get-app-info'
 import { GetArgsResult } from './get-args-result'
@@ -19,6 +22,7 @@ export async function getArgs(argv: string[], app: AppInfo, pm: PackageManager =
     .option('-d, --dry-run', help('Dry run (default: false)'))
     .option('-t, --template <template-name>', help('Use a template'))
     .option('--list-templates', help('List available templates'))
+    .option('--list-registry', help('List the templates in the registry'))
     .option('--list-versions', help('Verify your versions of Anchor, AVM, Rust, and Solana'))
     .option('--skip-git', help('Skip git initialization'))
     .option('--skip-init', help('Skip running the init script'))
@@ -42,8 +46,14 @@ Examples:
   // Get the options from the command line
   const result = input.opts()
 
+  const registry = await getRegistry()
+
   if (result.listVersions) {
     listVersions()
+    process.exit(0)
+  }
+  if (result.listRegistry) {
+    listRegistry(registry)
     process.exit(0)
   }
   if (result.listTemplates) {
@@ -115,4 +125,36 @@ function help(text: string) {
   return `
 
   ${text}`
+}
+
+function listRegistry(registry: Registry) {
+  const { default: defaultRegistry, ...otherRegistries } = registry
+
+  printRegistrySection(defaultRegistry)
+
+  const others = Object.keys(otherRegistries)
+
+  for (const key of others) {
+    printRegistrySection(otherRegistries[key])
+  }
+}
+
+function printRegistrySection(section: RegistrySection) {
+  console.log(` === ${section.id} === `)
+  console.log(`Name: ${section.name}`)
+  // console.log(`Description: ${section.description}`) // TODO: add description to index.json and the validation
+  console.log(`Groups: ${section.groups.length}`)
+
+  for (const group of section.groups) {
+    console.log(`  === ${group.id} === `)
+    console.log(`Name: ${group.name}`)
+    console.log(pico.gray(`Description: ${group.description}`))
+    console.log(pico.gray(`Templates: ${group.templates.length}`))
+
+    for (const template of group.templates) {
+      console.log(`    ${template.name}`)
+      console.log(pico.gray(`    Description: ${template.description}`))
+      console.log(pico.gray(`    Repository: ${template.repository}`))
+    }
+  }
 }


### PR DESCRIPTION
This PR changes the way how templates are handled by this CLI.

Currently, we have 6 hard-coded templates in this CLI. If we want to add a new template, we need to:

- we create a new template in its own repo
- ship an update to the CLI that includes that template
- manually ensure the template is kept in sync, is tested, etc.

By moving the CLI to work with a template registry, we get a few benefits:

- we create a new template in the registry
- we don't have to update the CLI but instead it will fetch the registry and list what's there
- we can have scripts that ensure templates are kept in sync, we can do tests for all templates at once.

