### PR TITLE
refactor: point templates to solana-templates repo

### DIFF
--- a/src/templates/frameworks.ts
+++ b/src/templates/frameworks.ts
@@ -7,8 +7,6 @@ export interface Framework {
   templates: Template[]
 }
 
-export const defaultRepository = `gh:solana-developers/template-{{name}}`
-
 export const frameworks: Framework[] = [
   {
     id: 'next',
@@ -18,17 +16,17 @@ export const frameworks: Framework[] = [
       {
         name: 'next-tailwind-counter',
         description: 'Next.js + Tailwind CSS + Anchor Counter Example',
-        repository: defaultRepository,
+        repository: 'gh:solana-developers/solana-templates/templates/legacy-next-tailwind-counter',
       },
       {
         name: 'next-tailwind-basic',
         description: 'Next.js + Tailwind CSS + Anchor Basic Example',
-        repository: defaultRepository,
+        repository: 'gh:solana-developers/solana-templates/templates/legacy-next-tailwind-basic',
       },
       {
         name: 'next-tailwind',
         description: 'Next.js + Tailwind CSS, no Anchor',
-        repository: defaultRepository,
+        repository: 'gh:solana-developers/solana-templates/templates/legacy-next-tailwind',
       },
     ],
   },
@@ -40,17 +38,17 @@ export const frameworks: Framework[] = [
       {
         name: 'react-vite-tailwind-counter',
         description: 'React with Vite + Tailwind CSS + Anchor Counter Example',
-        repository: defaultRepository,
+        repository: 'gh:solana-developers/solana-templates/templates/react-vite-tailwind-counter',
       },
       {
         name: 'react-vite-tailwind-basic',
         description: 'React with Vite + Tailwind CSS + Anchor Basic Example',
-        repository: defaultRepository,
+        repository: 'gh:solana-developers/solana-templates/templates/react-vite-tailwind-basic',
       },
       {
         name: 'react-vite-tailwind',
         description: 'React with Vite + Tailwind CSS, no Anchor',
-        repository: defaultRepository,
+        repository: 'gh:solana-developers/solana-templates/templates/react-vite-tailwind',
       },
     ],
   },

--- a/src/templates/templates.ts
+++ b/src/templates/templates.ts
@@ -7,7 +7,6 @@ export interface Template {
   name: string
   description: string
   repository: string
-  path?: string
 }
 
 export function findTemplate(name: string): Template {
@@ -35,15 +34,7 @@ function getTemplatesForFrameworks(frameworks: Framework[] = []): Template[] {
 }
 
 export function getTemplatesForFramework(framework: Framework): Template[] {
-  return (
-    framework.templates
-      // Normalize the template repository
-      .map((template) => ({
-        ...template,
-        repository: template.repository.replace('{{name}}', template.name),
-        path: template.path ?? '/',
-      }))
-  )
+  return framework.templates
 }
 
 export function listTemplates() {


### PR DESCRIPTION
This points the templates in the current version of the CLI to the new [solana-templates](https://github.com/solana-developers/solana-templates) repo before we add the registry feature #111 