### PR TITLE
fix type in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,5 @@ pnpm install
 pnpm build
 ```
 
-```
-
 Detailed instructions on the local development workflow are outlined in the
 [Development Workflow](./CONTRIBUTING.md#development-workflow) section of the CONTRIBUTING guidelines.
-```


### PR DESCRIPTION
fix typo in the readme making the contrib link be a code block