### PR TITLE
Revert "fix: don't test on Node 20"

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [22]
+        node: [20, 22]
         pm: [npm, pnpm, yarn]
         template: [
             legacy-next-tailwind,


### PR DESCRIPTION
This reverts commit 12447be108b217f38ef7dbb7879bfb6d7f71b525.


[This issue](https://github.com/anza-xyz/wallet-adapter/issues/1079) is now fixed and Node 20 is supported again.