### PR TITLE
chore: update template links to solana-templates repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ npx create-solana-dapp@latest
 The templates are supported within `create-solana-dapp`:
 
 - Next.js
-  - [Next.js + Tailwind CSS (no Anchor)](https://github.com/solana-developers/template-next-tailwind)
-  - [Next.js + Tailwind CSS + Anchor Basic Example](https://github.com/solana-developers/template-next-tailwind-basic)
-  - [Next.js + Tailwind CSS + Anchor Counter Example](https://github.com/solana-developers/template-next-tailwind-counter)
+  - [Next.js + Tailwind CSS (no Anchor)](https://github.com/solana-developers/solana-templates/tree/main/legacy/legacy-next-tailwind)
+  - [Next.js + Tailwind CSS + Anchor Basic Example](https://github.com/solana-developers/solana-templates/tree/main/legacy/legacy-next-tailwind-basic)
+  - [Next.js + Tailwind CSS + Anchor Counter Example](https://github.com/solana-developers/solana-templates/tree/main/legacy/legacy-next-tailwind-counter)
 - React with Vite
-  - [React with Vite + Tailwind CSS (no Anchor)](https://github.com/solana-developers/template-react-vite-tailwind)
-  - [React with Vite + Tailwind CSS + Anchor Basic Example](https://github.com/solana-developers/template-react-vite-tailwind-basic)
-  - [React with Vite + Tailwind CSS + Anchor Counter Example](https://github.com/solana-developers/template-react-vite-tailwind-counter)
+  - [React with Vite + Tailwind CSS (no Anchor)](https://github.com/solana-developers/solana-templates/tree/main/legacy/legacy-react-vite-tailwind)
+  - [React with Vite + Tailwind CSS + Anchor Basic Example](https://github.com/solana-developers/solana-templates/tree/main/legacy/legacy-react-vite-tailwind-basic)
+  - [React with Vite + Tailwind CSS + Anchor Counter Example](https://github.com/solana-developers/solana-templates/tree/main/legacy/legacy-react-vite-tailwind-counter)
 
 ## External templates
 


### PR DESCRIPTION
We are currently linking to a repository that is marked as archived and not where the code is being pulled from. I imagine the long term plan is to deprecate these templates entirely but until them I think we should link to the correct place where they are stored. This will avoid confusion and extra hops to find the code.