### PR TITLE
feat: allow templates to specify a minimum 'adb' version

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ in the project.
     },
     // Check versions and give a warning if it's not installed or the version is lower
     "versions": {
+      "adb": "33.0.0",
       "anchor": "0.30.1",
       "solana": "1.18.0",
     },

--- a/src/utils/create-app-task-run-init-script.ts
+++ b/src/utils/create-app-task-run-init-script.ts
@@ -1,11 +1,10 @@
 import { log } from '@clack/prompts'
 import { join } from 'node:path'
-import { bold, yellow } from 'picocolors'
 import { ensureTargetPath } from './ensure-target-path'
 import { GetArgsResult } from './get-args-result'
 import { deleteInitScript, getInitScript, InitScript } from './get-init-script'
+import { initCheckVersion } from './init-check-version'
 import { searchAndReplace } from './search-and-replace'
-import { validateAnchorVersion, validateSolanaVersion } from './validate-version'
 import { Task, taskFail } from './vendor/clack-tasks'
 import { namesValues } from './vendor/names'
 
@@ -83,61 +82,6 @@ async function initRename(args: GetArgsResult, init: InitScript, verbose: boolea
       }
       await searchAndReplace(join(args.targetDirectory, path), fromNames, toNames, args.dryRun)
     }
-  }
-}
-
-async function initCheckVersion(init: InitScript) {
-  if (init?.versions?.anchor) {
-    await initCheckVersionAnchor(init.versions.anchor)
-  }
-  if (init?.versions?.solana) {
-    await initCheckVersionSolana(init.versions.solana)
-  }
-}
-
-async function initCheckVersionAnchor(requiredVersion: string) {
-  try {
-    const { required, valid, version } = validateAnchorVersion(requiredVersion)
-    if (!version) {
-      log.warn(
-        [
-          bold(yellow(`Could not find Anchor version. Please install Anchor.`)),
-          'https://www.anchor-lang.com/docs/installation',
-        ].join(' '),
-      )
-    } else if (!valid) {
-      log.warn(
-        [
-          yellow(`Found Anchor version ${version}. Expected Anchor version ${required}.`),
-          'https://www.anchor-lang.com/release-notes/0.30.1',
-        ].join(' '),
-      )
-    }
-  } catch (error_) {
-    log.warn(`Error ${error_}`)
-  }
-}
-
-async function initCheckVersionSolana(requiredVersion: string) {
-  try {
-    const { required, valid, version } = validateSolanaVersion(requiredVersion)
-    if (!version) {
-      log.warn(
-        [
-          bold(yellow(`Could not find Solana version. Please install Solana.`)),
-          'https://docs.solana.com/cli/install-solana-cli-tools',
-        ].join(' '),
-      )
-    } else if (!valid) {
-      log.warn(
-        [
-          yellow(`Found Solana version ${version}. Expected Solana version ${required}.`),
-          'https://docs.solana.com/cli/install-solana-cli-tools',
-        ].join(' '),
-      )
-    }
-  } catch (error_) {
-    log.warn(`Error ${error_}`)
   }
 }
 

--- a/src/utils/get-args.ts
+++ b/src/utils/get-args.ts
@@ -4,7 +4,7 @@ import { findTemplate, listTemplates, Template } from '../templates/templates'
 import { AppInfo } from './get-app-info'
 import { GetArgsResult } from './get-args-result'
 import { getPrompts } from './get-prompts'
-import { listVersions } from './validate-version'
+import { listVersions } from './list-versions'
 import { PackageManager } from './vendor/package-manager'
 
 export async function getArgs(argv: string[], app: AppInfo, pm: PackageManager = 'npm'): Promise<GetArgsResult> {

--- a/src/utils/get-init-script.ts
+++ b/src/utils/get-init-script.ts
@@ -45,6 +45,7 @@ const InitScriptSchema = z
       .optional(),
     versions: z
       .object({
+        adb: z.string().optional(),
         anchor: z.string().optional(),
         solana: z.string().optional(),
       })

--- a/src/utils/get-version.ts
+++ b/src/utils/get-version.ts
@@ -1,24 +1,42 @@
 import { parseVersion } from './parse-version'
 
-export function getVersion(command: string, regex: RegExp): string | undefined {
+export const versionCommands: Record<string, { command: string; name: string; regex: RegExp }> = {
+  adb: {
+    command: 'adb --version',
+    name: 'Adb   ',
+    regex: /Version (\d+\.\d+\.\d+)/,
+  },
+  anchor: {
+    command: 'anchor --version',
+    name: 'Anchor',
+    regex: /anchor-cli (\d+\.\d+\.\d+)/,
+  },
+  avm: {
+    command: 'avm --version',
+    name: 'AVM   ',
+    regex: /avm (\d+\.\d+\.\d+)/,
+  },
+  rust: {
+    command: 'rustc --version',
+    name: 'Rust  ',
+    regex: /rustc (\d+\.\d+\.\d+)/,
+  },
+  solana: {
+    command: 'solana --version',
+    name: 'Solana',
+    regex: /solana-cli (\d+\.\d+\.\d+)/,
+  },
+}
+
+export function getVersion(command: keyof typeof versionCommands): string | undefined {
+  const cmd = versionCommands[command]
+  if (!cmd) {
+    throw new Error(`Unknown command ${command}`)
+  }
+
   try {
-    return parseVersion(command, regex)
+    return parseVersion(cmd.command, cmd.regex)
   } catch {
     return undefined
   }
-}
-
-export function getVersionAnchor(): string | undefined {
-  return getVersion('anchor --version', /anchor-cli (\d+\.\d+\.\d+)/)
-}
-
-export function getVersionSolana(): string | undefined {
-  return getVersion('solana --version', /solana-cli (\d+\.\d+\.\d+)/)
-}
-
-export function getVersionRust(): string | undefined {
-  return getVersion('rustc --version', /rustc (\d+\.\d+\.\d+)/)
-}
-export function getVersionAvm(): string | undefined {
-  return getVersion('avm --version', /avm (\d+\.\d+\.\d+)/)
 }

--- a/src/utils/init-check-version-adb.ts
+++ b/src/utils/init-check-version-adb.ts
@@ -1,0 +1,27 @@
+import { log } from '@clack/prompts'
+import { bold, yellow } from 'picocolors'
+import { getVersion } from './get-version'
+import { validateVersion } from './validate-version'
+
+export async function initCheckVersionAdb(required: string) {
+  try {
+    const { valid, version } = validateVersion({ required, version: getVersion('adb') })
+    if (!version) {
+      log.warn(
+        [
+          bold(yellow(`Could not find adb version. Please install adb.`)),
+          'https://docs.expo.dev/get-started/set-up-your-environment/?platform=android&device=physical&mode=development-build&buildEnv=local',
+        ].join(' '),
+      )
+    } else if (!valid) {
+      log.warn(
+        [
+          yellow(`Found adb version ${version}. Expected adb version ${required}.`),
+          'https://docs.expo.dev/get-started/set-up-your-environment/?platform=android&device=physical&mode=development-build&buildEnv=local',
+        ].join(' '),
+      )
+    }
+  } catch (error_) {
+    log.warn(`Error ${error_}`)
+  }
+}

--- a/src/utils/init-check-version-anchor.ts
+++ b/src/utils/init-check-version-anchor.ts
@@ -1,0 +1,27 @@
+import { log } from '@clack/prompts'
+import { bold, yellow } from 'picocolors'
+import { getVersion } from './get-version'
+import { validateVersion } from './validate-version'
+
+export async function initCheckVersionAnchor(required: string) {
+  try {
+    const { valid, version } = validateVersion({ required, version: getVersion('anchor') })
+    if (!version) {
+      log.warn(
+        [
+          bold(yellow(`Could not find Anchor version. Please install Anchor.`)),
+          'https://www.anchor-lang.com/docs/installation',
+        ].join(' '),
+      )
+    } else if (!valid) {
+      log.warn(
+        [
+          yellow(`Found Anchor version ${version}. Expected Anchor version ${required}.`),
+          'https://www.anchor-lang.com/release-notes/0.30.1',
+        ].join(' '),
+      )
+    }
+  } catch (error_) {
+    log.warn(`Error ${error_}`)
+  }
+}

--- a/src/utils/init-check-version-solana.ts
+++ b/src/utils/init-check-version-solana.ts
@@ -1,0 +1,27 @@
+import { log } from '@clack/prompts'
+import { bold, yellow } from 'picocolors'
+import { getVersion } from './get-version'
+import { validateVersion } from './validate-version'
+
+export async function initCheckVersionSolana(required: string) {
+  try {
+    const { valid, version } = validateVersion({ required, version: getVersion('solana') })
+    if (!version) {
+      log.warn(
+        [
+          bold(yellow(`Could not find Solana version. Please install Solana.`)),
+          'https://docs.solana.com/cli/install-solana-cli-tools',
+        ].join(' '),
+      )
+    } else if (!valid) {
+      log.warn(
+        [
+          yellow(`Found Solana version ${version}. Expected Solana version ${required}.`),
+          'https://docs.solana.com/cli/install-solana-cli-tools',
+        ].join(' '),
+      )
+    }
+  } catch (error_) {
+    log.warn(`Error ${error_}`)
+  }
+}

--- a/src/utils/init-check-version.ts
+++ b/src/utils/init-check-version.ts
@@ -1,0 +1,16 @@
+import { InitScript } from './get-init-script'
+import { initCheckVersionAdb } from './init-check-version-adb'
+import { initCheckVersionAnchor } from './init-check-version-anchor'
+import { initCheckVersionSolana } from './init-check-version-solana'
+
+export async function initCheckVersion(init: InitScript) {
+  if (init?.versions?.adb) {
+    await initCheckVersionAdb(init.versions.adb)
+  }
+  if (init?.versions?.anchor) {
+    await initCheckVersionAnchor(init.versions.anchor)
+  }
+  if (init?.versions?.solana) {
+    await initCheckVersionSolana(init.versions.solana)
+  }
+}

--- a/src/utils/list-versions.ts
+++ b/src/utils/list-versions.ts
@@ -1,0 +1,8 @@
+import { getVersion, versionCommands } from './get-version'
+
+export function listVersions() {
+  console.log(`Installed versions:`)
+  for (const command of Object.keys(versionCommands)) {
+    console.log(`  ${versionCommands[command].name}: ${getVersion(command) ?? 'not installed'}`)
+  }
+}

--- a/src/utils/validate-version.ts
+++ b/src/utils/validate-version.ts
@@ -1,45 +1,10 @@
 import * as semver from 'semver'
-import { getVersionAnchor, getVersionAvm, getVersionRust, getVersionSolana } from './get-version'
 
-export type ValidateVersionResult = {
-  required: string
+export function validateVersion({ required, version }: { required: string; version?: string | undefined }): {
   valid: boolean
   version: string | undefined
-}
-
-export function validateVersion({
-  required,
-  version,
-}: {
-  required: string
-  version?: string | undefined
-}): ValidateVersionResult {
+} {
   const valid = semver.satisfies(version ?? '', `>=${required}`)
 
-  return {
-    required,
-    valid,
-    version,
-  }
-}
-
-export function validateAnchorVersion(required: string): ValidateVersionResult {
-  return validateVersion({ required, version: getVersionAnchor() })
-}
-
-export function validateSolanaVersion(required: string): ValidateVersionResult {
-  return validateVersion({ required, version: getVersionSolana() })
-}
-
-export function listVersions() {
-  const anchor = getVersionAnchor()
-  const avm = getVersionAvm()
-  const rust = getVersionRust()
-  const solana = getVersionSolana()
-
-  console.log(`Locally installed versions:`)
-  console.log(`  Anchor: ${anchor}`)
-  console.log(`  AVM   : ${avm}`)
-  console.log(`  Rust  : ${rust}`)
-  console.log(`  Solana: ${solana}`)
+  return { valid, version }
 }


### PR DESCRIPTION
This PR adds support for specifying the `adb` version in the `versions` object in the [`init-script`](https://github.com/solana-developers/create-solana-dapp?tab=readme-ov-file#init-script)