### PR TITLE
refactor: remove dummy test

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,7 +1,0 @@
-import { describe, expect, it } from 'vitest'
-
-describe('create-solana-dapp', () => {
-  it.todo('pass', () => {
-    expect(true).toBe(true)
-  })
-})


### PR DESCRIPTION
This was a dummy test to make `vitest` go green before any tests existed.