### PR TITLE
chore: add Dockerfile for running ephemeral dev containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:22-alpine AS base
+
+WORKDIR /workspace
+
+RUN apk add --no-cache bash git
+RUN echo "export PS1='\w # '" >> ~/.bashrc
+
+RUN corepack enable && corepack use pnpm@latest-10
+RUN echo "export CMD=\"node /workspace/dist/bin/index.cjs --pnpm --verbose\"" >> ~/.bashrc
+
+COPY csd.sh /usr/local/bin/csd
+
+COPY package.json pnpm-lock.yaml /workspace/
+RUN pnpm install --frozen-lockfile
+
+ENTRYPOINT ["bash"]

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "build": "unbuild",
     "build:watch": "unbuild --watch",
     "dev": "vitest dev",
+    "docker:build": "docker build -t create-solana-dapp:latest .",
+    "docker:run": "docker run --rm --name create-solana-dapp -v \"${PWD}/dist:/workspace/dist\" -it create-solana-dapp:latest",
     "lint": "eslint . && prettier -c .",
     "lint:fix": "automd && eslint . --fix && prettier -w .",
     "prepublishOnly": "pnpm pkg delete devDependencies",


### PR DESCRIPTION
This PR adds a Dockerfile that can be used to spin up ephemeral dev containers to quickly create an app and inspect the output.

Build and run it:

```shell
pnpm docker:build && pnpm docker:run
```

Inside the container, run [`csd`](https://github.com/solana-developers/create-solana-dapp/blob/main/csd.sh) to start a new app with a random name.

If you move out of the container, the environment is gone. 

