### PR TITLE
fix: update picocolors import to resolve SyntaxError in ESM module

### DIFF
--- a/.changeset/six-clouds-try.md
+++ b/.changeset/six-clouds-try.md
@@ -1,0 +1,5 @@
+---
+'create-solana-dapp': patch
+---
+
+update picocolors import to resolve SyntaxError in ESM module

--- a/src/utils/final-note.ts
+++ b/src/utils/final-note.ts
@@ -1,4 +1,4 @@
-import { bold, white } from 'picocolors'
+import pico from 'picocolors'
 import { GetArgsResult } from './get-args-result'
 import { getPackageJson } from './get-package-json'
 import { getStartScript } from './get-start-script'
@@ -29,5 +29,5 @@ function cmd(pm: string, command: string) {
 }
 
 function msg(message: string) {
-  return bold(white(message))
+  return pico.bold(pico.white(message))
 }

--- a/src/utils/init-script-version-check.ts
+++ b/src/utils/init-script-version-check.ts
@@ -1,5 +1,5 @@
 import { log } from '@clack/prompts'
-import { bold, yellow } from 'picocolors'
+import pico from 'picocolors'
 import { getVersion } from './get-version'
 import { VersionCommand } from './get-version-command'
 import { getVersionUrls } from './get-version-urls'
@@ -25,7 +25,7 @@ export async function initScriptVersionCheck(versionCommand: VersionCommand, req
     if (!version) {
       log.warn(
         [
-          bold(yellow(`Could not find ${versionCommand} version. Please install ${versionCommand}.`)),
+          pico.bold(pico.yellow(`Could not find ${versionCommand} version. Please install ${versionCommand}.`)),
           install?.replace('{required}', required),
         ].join(' '),
       )
@@ -34,7 +34,7 @@ export async function initScriptVersionCheck(versionCommand: VersionCommand, req
     if (!valid) {
       log.warn(
         [
-          yellow(`Found ${versionCommand} version ${version}. Expected ${versionCommand} version ${required}.`),
+          pico.yellow(`Found ${versionCommand} version ${version}. Expected ${versionCommand} version ${required}.`),
           update?.replace('{required}', required),
         ].join(' '),
       )


### PR DESCRIPTION
When installing `create-solana-dapp` as a package in an esm project, it fails with this error.

```ts
import { bold, yellow, white } from 'picocolors';
         ^^^^
SyntaxError: The requested module 'picocolors' does not provide an export named 'bold'
    at ModuleJob._instantiate (node:internal/modules/esm/module_job:182:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:266:5)
    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:268:26)
    at async ModuleLoader.executeModuleJob (node:internal/modules/esm/loader:264:20)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5)
```
This PR should fix it.