### PR TITLE
refactor: don't show the start script if instructions are provided

### DIFF
--- a/src/utils/final-note.ts
+++ b/src/utils/final-note.ts
@@ -11,14 +11,17 @@ export interface FinalNoteArgs extends GetArgsResult {
 export function finalNote(args: FinalNoteArgs): string {
   const { contents } = getPackageJson(args.targetDirectory)
   const startScript = getStartScript(contents.scripts)
+  const instructions =
+    args.instructions.length > 0
+      ? args.instructions
+      : [...(startScript ? [`Start the app:`, cmd(args.packageManager, startScript)] : [])]
 
   const lines: string[] = [
     `That's it!`,
-    `Change to your new directory and start developing:`,
+    `Change to your new directory:`,
     msg(`cd ${args.target}`),
     ...(args.skipInstall ? [`Install dependencies:`, msg(`${args.packageManager} install`)] : []),
-    ...(startScript ? [`Start the app:`, cmd(args.packageManager, startScript)] : []),
-    ...args.instructions.map((line) => (line.startsWith('+') ? msg(line.slice(1)) : line)),
+    ...instructions.map((line) => (line.startsWith('+') ? msg(line.slice(1)) : line)),
   ]
 
   return lines.filter(Boolean).join('\n\n')

--- a/test/final-note.test.ts
+++ b/test/final-note.test.ts
@@ -1,7 +1,7 @@
+import { fs, vol } from 'memfs'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { finalNote, FinalNoteArgs } from '../src/utils/final-note'
-import { fs, vol } from 'memfs'
 
 vi.mock('node:fs')
 
@@ -59,5 +59,29 @@ describe('finalNote', () => {
     })
 
     expect(result).toContain('yarn install')
+  })
+
+  it('should show the start script if there is no instructions array', () => {
+    const packageJson = { scripts: { dev: 'vite', start: 'node server.js' } }
+    fs.mkdirSync('/template')
+    fs.writeFileSync('/template/package.json', JSON.stringify(packageJson))
+
+    const result = finalNote({ ...baseArgs, instructions: [] })
+
+    expect(result).toContain('Start the app:')
+    expect(result).toContain('npm run dev')
+  })
+
+  it('should show the start script and instructions if they are provided', () => {
+    const packageJson = { scripts: { dev: 'vite', start: 'node server.js' } }
+    fs.mkdirSync('/template')
+    fs.writeFileSync('/template/package.json', JSON.stringify(packageJson))
+
+    const result = finalNote({ ...baseArgs, instructions: ['Start the Expo dev server:', 'npm run android'] })
+
+    expect(result).toContain('Start the Expo dev server:')
+    expect(result).toContain('npm run android')
+    expect(result).not.toContain('Start the app:')
+    expect(result).not.toContain('npm run dev')
   })
 })


### PR DESCRIPTION
This patch changes the way the `instructions` in the `init-script` are handled.

If the instructions are found, it will skip the default suggestion to start the dev server (`npm run dev/start`) and show the instructions instead.