### PR TITLE
chore: don't run e2e tests when Markdown files are changed

### DIFF
--- a/.changeset/update-e2e-test-trigger.md
+++ b/.changeset/update-e2e-test-trigger.md
@@ -1,0 +1,5 @@
+---
+'create-solana-dapp': patch
+---
+
+don't run e2e tests when Markdown files are changed

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -8,7 +8,11 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
   pull_request:
+    paths-ignore:
+      - '**/*.md'
 
 jobs:
   test:


### PR DESCRIPTION
Updates and merges #174.

Closes #154 .