### PR TITLE
chore: add `lefthook` to automate linting/formatting

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-pnpm verify-pnpm-lock
-pnpm sync-readmes --check
-pnpm sync-schemas --check
-pnpm lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-pnpm nx format:check

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,15 @@
+pre-commit:
+  parallel: true
+  jobs:
+    - name: Lint files
+      exclude:
+        - '*.json'
+        - '*.yaml'
+        - '*.yml'
+      run: pnpm lint --fix {staged_files}
+      stage_fixed: true
+    - name: Format files
+      glob:
+        - '*.json'
+        - '**/*.json'
+      run: pnpm prettier --write {staged_files}

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "eslint-config-unjs": "^0.5.0",
     "eslint-plugin-prettier": "^5.5.4",
     "eslint-plugin-sort": "^4.0.0",
+    "lefthook": "^1.12.4",
     "memfs": "^4.39.0",
     "mock-fs": "^5.5.0",
     "prettier": "^3.6.2",
@@ -69,6 +70,11 @@
     "vitest": "^3.2.4"
   },
   "packageManager": "pnpm@10.15.1",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "lefthook"
+    ]
+  },
   "dependencies": {
     "@beeman/repokit": "0.0.0-canary-20250801172233",
     "@clack/prompts": "0.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       eslint-plugin-sort:
         specifier: ^4.0.0
         version: 4.0.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2)
+      lefthook:
+        specifier: ^1.12.4
+        version: 1.12.4
       memfs:
         specifier: ^4.39.0
         version: 4.39.0
@@ -2101,6 +2104,60 @@ packages:
   latest-version@9.0.0:
     resolution: {integrity: sha512-7W0vV3rqv5tokqkBAFV1LbR7HPOWzXQDpDgEuib/aJ1jsZZx6x3c2mBI+TJhJzOhkGeaLbCKEHXEXLfirtG2JA==}
     engines: {node: '>=18'}
+
+  lefthook-darwin-arm64@1.12.4:
+    resolution: {integrity: sha512-/eBd9GnBS9Js2ZsHzipj2cV8siFex/g6MgBSeIxsHBJNkQFq4O42ItWxUir5Q43zFvZCjGizBlhklbmubGOZfg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  lefthook-darwin-x64@1.12.4:
+    resolution: {integrity: sha512-WDO0oR3pIAIBTZtn4/4dC0GRyrfJtPGckYbqshpH4Fkuxyy7nRGy3su+uY8kiiVYLy/nvELY2eoqnT1Rp4njFQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  lefthook-freebsd-arm64@1.12.4:
+    resolution: {integrity: sha512-/VNBWQvAsLuVilS7JB+pufTjuoj06Oz5YdGWUCo6u2XCKZ6UHzwDtGDJ0+3JQMSg8613gHmAdkGoByKjxqZSkQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  lefthook-freebsd-x64@1.12.4:
+    resolution: {integrity: sha512-bY6klVVeBoiQEimb/z5TC5IFyczak9VOVQ8b+S/QAy+tvKo9TY6FdGwy7yxgoqTzfEkirDQxVOkalQsM/11xsg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  lefthook-linux-arm64@1.12.4:
+    resolution: {integrity: sha512-iU+tPCNcX1pztk5Zjs02+sOnjZj9kCrLn6pg954WMr9dZTIaEBljRV+ybBP/5zLlv2wfv5HFBDKDKNRYjOVF+A==}
+    cpu: [arm64]
+    os: [linux]
+
+  lefthook-linux-x64@1.12.4:
+    resolution: {integrity: sha512-IXYUSBYetftYmdii2aGIjv7kxO2m+jTYjaEoldtCDcXAPz/yV78Xx2WzY/LYNJsJ1vzbUhBqVOeRCHCwLXusTQ==}
+    cpu: [x64]
+    os: [linux]
+
+  lefthook-openbsd-arm64@1.12.4:
+    resolution: {integrity: sha512-3DFLbqAlAeoqo//PE20NcGKJzBqAMbS/roPvaJ9DYA95MSywMig2jxyDoZbBhyP/J/iuFO3op7emtwgwousckA==}
+    cpu: [arm64]
+    os: [openbsd]
+
+  lefthook-openbsd-x64@1.12.4:
+    resolution: {integrity: sha512-Nlxn3lXHK3hRDL5bP5W6+LleE9CRIc6GJ84xTo9EPwI40utsM8olAm+pFFRnE9szkHvQTkXwoBhqi2C5laxoGQ==}
+    cpu: [x64]
+    os: [openbsd]
+
+  lefthook-windows-arm64@1.12.4:
+    resolution: {integrity: sha512-tWOfrTC9GNheaFXFt49G5nbBUYLqd2NBb5XW97dSLO/lU81cvuvRsMKZFBrq48LvByT7PLwEuibMuO1TminhHA==}
+    cpu: [arm64]
+    os: [win32]
+
+  lefthook-windows-x64@1.12.4:
+    resolution: {integrity: sha512-3B295z3tdcdDrKrY98b/cSm4Elb/TXWMVQuH2xW15CJp9QY6jsgRpFJyBdyz4ggrPFhNUVnLKCpm6/saqeZWHA==}
+    cpu: [x64]
+    os: [win32]
+
+  lefthook@1.12.4:
+    resolution: {integrity: sha512-VhTFYGT55pD2hytjcn6Lckb0tCbG1Cke6rszTWVQVJpnJZ0EqQW+Pl+JYQLlruR8MO4RGFVU0UBUw17/g9TYxA==}
+    hasBin: true
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -5076,6 +5133,49 @@ snapshots:
   latest-version@9.0.0:
     dependencies:
       package-json: 10.0.1
+
+  lefthook-darwin-arm64@1.12.4:
+    optional: true
+
+  lefthook-darwin-x64@1.12.4:
+    optional: true
+
+  lefthook-freebsd-arm64@1.12.4:
+    optional: true
+
+  lefthook-freebsd-x64@1.12.4:
+    optional: true
+
+  lefthook-linux-arm64@1.12.4:
+    optional: true
+
+  lefthook-linux-x64@1.12.4:
+    optional: true
+
+  lefthook-openbsd-arm64@1.12.4:
+    optional: true
+
+  lefthook-openbsd-x64@1.12.4:
+    optional: true
+
+  lefthook-windows-arm64@1.12.4:
+    optional: true
+
+  lefthook-windows-x64@1.12.4:
+    optional: true
+
+  lefthook@1.12.4:
+    optionalDependencies:
+      lefthook-darwin-arm64: 1.12.4
+      lefthook-darwin-x64: 1.12.4
+      lefthook-freebsd-arm64: 1.12.4
+      lefthook-freebsd-x64: 1.12.4
+      lefthook-linux-arm64: 1.12.4
+      lefthook-linux-x64: 1.12.4
+      lefthook-openbsd-arm64: 1.12.4
+      lefthook-openbsd-x64: 1.12.4
+      lefthook-windows-arm64: 1.12.4
+      lefthook-windows-x64: 1.12.4
 
   levn@0.4.1:
     dependencies:


### PR DESCRIPTION
This adds and configures `lefthook` to run linting and formatting on pre-commit.

Fixes #151 