### PR TITLE
Revert "fix: file/folder renaming and content replacement in init script (#196)

### DIFF
--- a/src/utils/search-and-replace.ts
+++ b/src/utils/search-and-replace.ts
@@ -1,5 +1,5 @@
 import { readdir, readFile, rename, writeFile } from 'node:fs/promises'
-import { basename, extname, join } from 'node:path'
+import { join } from 'node:path'
 
 const EXCLUDED_DIRECTORIES = new Set(['dist', 'coverage', 'node_modules', '.git', 'tmp'])
 
@@ -14,30 +14,18 @@ export async function searchAndReplace(
     throw new Error('fromStrings and toStrings arrays must have the same length')
   }
 
-  // Helper: check if a segment exactly matches any fromString (positional)
-  function findReplacementForSegment(segment: string): string | undefined {
-    for (const [i, from] of fromStrings.entries()) {
-      if (segment === from) {
-        return toStrings[i]
-      }
-    }
-    return undefined
-  }
-
   async function processFile(filePath: string): Promise<void> {
     try {
       const content = await readFile(filePath, 'utf8')
       let newContent = content
 
       for (const [i, fromString] of fromStrings.entries()) {
-        // Use a safer word-boundary regex for content replacement
-        const regex = new RegExp(`\\b${fromString}\\b`, 'g')
+        const regex = new RegExp(fromString, 'g')
         newContent = newContent.replace(regex, toStrings[i])
-      }
-
-      // Preserve trailing newline if it existed
-      if (content.endsWith('\n') && !newContent.endsWith('\n')) {
-        newContent += '\n'
+        // Make sure we maintain the possible newline at the end of the file
+        if (content.endsWith('\n') && !newContent.endsWith('\n')) {
+          newContent += '\n'
+        }
       }
 
       if (content !== newContent) {
@@ -46,11 +34,11 @@ export async function searchAndReplace(
         }
         if (isVerbose) {
           console.log(`${isDryRun ? '[Dry Run] ' : ''}File modified: ${filePath}`)
-          for (const [index, fromStr] of fromStrings.entries()) {
-            const count = (newContent.match(new RegExp(toStrings[index], 'g')) || []).length
-            if (count > 0) {
-              console.log(`  Replaced "${fromStr}" with "${toStrings[index]}" ${count} time(s)`)
-            }
+        }
+        for (const [index, fromStr] of fromStrings.entries()) {
+          const count = (newContent.match(new RegExp(toStrings[index], 'g')) || []).length
+          if (count > 0 && isVerbose) {
+            console.log(`  Replaced "${fromStr}" with "${toStrings[index]}" ${count} time(s)`)
           }
         }
       }
@@ -93,45 +81,39 @@ export async function searchAndReplace(
   }
 
   async function renamePaths(directoryPath: string): Promise<void> {
-    const entries = await readdir(directoryPath, { withFileTypes: true })
+    try {
+      const entries = await readdir(directoryPath, { withFileTypes: true })
 
-    for (const entry of entries) {
-      if (EXCLUDED_DIRECTORIES.has(entry.name)) {
-        if (isVerbose) {
-          console.log(`Found in excluded directory: ${entry.name}`)
+      for (const entry of entries) {
+        if (EXCLUDED_DIRECTORIES.has(entry.name)) {
+          if (isVerbose) {
+            console.log(`Skipping excluded directory for renaming: ${join(directoryPath, entry.name)}`)
+          }
+          continue
         }
-        continue
-      }
 
-      const oldPath = join(directoryPath, entry.name)
+        const oldPath = join(directoryPath, entry.name)
+        let newPath = oldPath
 
-      // Recurse first
-      if (entry.isDirectory()) {
-        await renamePaths(oldPath)
-      }
+        for (const [i, fromString] of fromStrings.entries()) {
+          newPath = newPath.replace(new RegExp(fromString, 'g'), toStrings[i])
+        }
 
-      // Split name and extension
-      const ext = extname(entry.name)
-      const base = basename(entry.name, ext)
-
-      // Check if the basename matches fromStrings
-      const replacement = findReplacementForSegment(base)
-      const newName = replacement ? replacement + ext : entry.name
-      const newPath = join(directoryPath, newName)
-
-      if (oldPath !== newPath) {
-        if (!isDryRun) {
-          try {
+        if (oldPath !== newPath) {
+          if (!isDryRun) {
             await rename(oldPath, newPath)
-          } catch (error) {
-            console.error(`Failed to rename ${oldPath} -> ${newPath}:`, error)
-            continue
+          }
+          if (isVerbose) {
+            console.log(`${isDryRun ? '[Dry Run] ' : ''}Renamed: ${oldPath} -> ${newPath}`)
           }
         }
-        if (isVerbose) {
-          console.log(`${isDryRun ? '[Dry Run] ' : ''}Renamed: ${oldPath} -> ${newPath}`)
+
+        if (entry.isDirectory()) {
+          await renamePaths(entry.isDirectory() ? newPath : oldPath)
         }
       }
+    } catch (error) {
+      console.error(`Error renaming paths in ${directoryPath}:`, error)
     }
   }
 


### PR DESCRIPTION

This reverts commit 096f365a5f376c7d234f78e2475f231396e63013.


Looks like this update breaks some of the templates https://github.com/solana-foundation/create-solana-dapp/actions/runs/17658074154