### PR TITLE
feat: add `--minimal` flag to that selects 'gill-next-tailwind-minimal'

### DIFF
--- a/.changeset/puny-experts-stand.md
+++ b/.changeset/puny-experts-stand.md
@@ -1,0 +1,5 @@
+---
+'create-solana-dapp': minor
+---
+
+add `--minimal` flag to that selects 'gill-next-tailwind-minimal'

--- a/src/utils/get-args.ts
+++ b/src/utils/get-args.ts
@@ -15,6 +15,8 @@ import { runVersionCheck } from './run-version-check'
 import { Template } from './template'
 import { PackageManager } from './vendor/package-manager'
 
+const minimalTemplateName = 'gill-next-tailwind-minimal'
+
 export async function getArgs(argv: string[], app: AppInfo, pm: PackageManager = 'npm'): Promise<GetArgsResult> {
   // Get the result from the command line
   const input = program
@@ -30,6 +32,7 @@ export async function getArgs(argv: string[], app: AppInfo, pm: PackageManager =
     .option('--list-template-ids', help('List available template ids as JSON array'))
     .option('--list-templates', help('List available templates'))
     .option('--list-versions', help('Verify your versions of Anchor, AVM, Rust, and Solana'))
+    .option('--minimal', help(`Select the minimal template (${minimalTemplateName})`), false)
     .option('--skip-git', help('Skip git initialization'))
     .option('--skip-init', help('Skip running the init script'))
     .option('--skip-install', help('Skip installing dependencies'))
@@ -101,6 +104,14 @@ Examples:
   intro(`${app.name} ${app.version}`)
 
   let template: Template | undefined
+
+  if (result.template && result.minimal) {
+    throw new Error(`The --minimal flag can't be used in combination with --template. Please specify only one.`)
+  }
+
+  if (result.minimal) {
+    result.template = minimalTemplateName
+  }
 
   if (result.template) {
     template = findTemplate({ name: result.template, templates, verbose })


### PR DESCRIPTION
This is a follow-up of https://github.com/solana-foundation/templates/pull/119 that added minimal templates to the templates repo.

These commit introduces the `--minimal` flag that automatically selects the `gill-next-tailwind-minimal` template. 

It can be invoked like this, which will skip the template selection menu:

```shell
pnpx create-solana-dapp@latest --minimal
```

In addition, a check is added to ensure that `--minimal` and `--template` are not both passed in as they're mutually exclusive.

To test the `pkg.pr.new` version, invoke this:

```shell
pnpx https://pkg.pr.new/solana-foundation/create-solana-dapp@205 --minimal
```