### PR TITLE
fix: update solana docs url

### DIFF
--- a/.changeset/tricky-apes-beg.md
+++ b/.changeset/tricky-apes-beg.md
@@ -1,0 +1,5 @@
+---
+'create-solana-dapp': patch
+---
+
+update solana docs url

--- a/src/utils/get-version-urls.ts
+++ b/src/utils/get-version-urls.ts
@@ -15,7 +15,7 @@ const urls: Record<VersionCommand, VersionUrls> = {
     update: 'https://www.anchor-lang.com/release-notes/{required}',
   },
   solana: {
-    install: 'https://docs.solana.com/cli/install-solana-cli-tools',
+    install: 'https://solana.com/docs/intro/installation',
   },
 }
 

--- a/test/get-version-urls.test.ts
+++ b/test/get-version-urls.test.ts
@@ -25,8 +25,8 @@ describe('getVersionUrls', () => {
   it('should return install url for "solana"', () => {
     const urls = getVersionUrls('solana' as VersionCommand, '')
     expect(urls).toEqual({
-      install: 'https://docs.solana.com/cli/install-solana-cli-tools',
-      update: 'https://docs.solana.com/cli/install-solana-cli-tools',
+      install: 'https://solana.com/docs/intro/installation',
+      update: 'https://solana.com/docs/intro/installation',
     })
   })
 


### PR DESCRIPTION
Solana docs URL to installation guide changed, this PR updates it.

Before:
<img width="1346" height="838" alt="image" src="https://github.com/user-attachments/assets/26e1a0b7-4b69-46c1-b13a-dde6dae2ee07" />


After:
<img width="1342" height="811" alt="image" src="https://github.com/user-attachments/assets/19d1761d-b303-4cc9-b52c-01f228eef05a" />
