### PR TITLE
feat: support `in` alias for rename entries

### DIFF
--- a/test/init-script-schema.test.ts
+++ b/test/init-script-schema.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { InitScriptSchema } from '../src/utils/init-script-schema'
+
+describe('InitScriptSchema - rename alias', () => {
+  const parseRename = (rename: unknown) => InitScriptSchema.parse({ rename }).rename
+
+  it('should accept `in` alias and normalize to `paths`', () => {
+    const parsed = parseRename({ example: { in: ['some/path/to/file'], to: '{{name}}Example' } } as unknown)
+
+    // @ts-expect-error normalized by schema transform
+    expect(parsed.example.in).toBeUndefined()
+    expect(parsed?.example.paths).toEqual(['some/path/to/file'])
+    expect(parsed?.example.to).toBe('{{name}}Example')
+  })
+
+  it('should accept `paths` field without changes', () => {
+    const parsed = parseRename({ example: { paths: ['some/path/to/file'], to: '{{name}}Example' } })
+
+    expect(parsed?.example.paths).toEqual(['some/path/to/file'])
+    expect(parsed?.example.to).toBe('{{name}}Example')
+  })
+
+  it('should prioritize `paths` over `in` when both provided', () => {
+    const entry = { in: ['path/from/in'], paths: ['path/from/paths'], to: '{{name}}Example' } as unknown
+    const parsed = parseRename({ example: entry })
+
+    expect(parsed?.example.paths).toEqual(['path/from/paths'])
+  })
+
+  it('should handle empty arrays', () => {
+    const parsed = parseRename({ example: { in: [], to: '{{name}}Example' } } as unknown)
+
+    expect(parsed?.example.paths).toEqual([])
+  })
+
+  it('should handle mixed `in` and `paths` usage', () => {
+    const rename = {
+      example1: { in: ['some/path/to/file1'], to: '{{name}}Example1' },
+      example2: { paths: ['some/path/to/file2'], to: '{{name}}Example2' },
+    } as unknown
+    const parsed = parseRename(rename)
+
+    expect(parsed?.example1.paths).toEqual(['some/path/to/file1'])
+    expect(parsed?.example2.paths).toEqual(['some/path/to/file2'])
+  })
+})

--- a/test/search-and-replace.test.ts
+++ b/test/search-and-replace.test.ts
@@ -98,7 +98,7 @@ describe('searchAndReplace', () => {
   })
 
   it('should handle errors gracefully', async () => {
-    const consoleErrorSpy = vi.spyOn(console, 'error')
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
     // Mock the file system and simulate an error for readFile
     mockFs({


### PR DESCRIPTION
in commit `813773d4`, @beeman mentioned that `paths` should be renamed to `in`. This PR basically adds support for it + maintain backward compatibility.

## Feat added
- Accepts `in` alias alongside `paths` in rename entries
- Normalizes `in` to `paths` in `InitScriptSchemaRename`
- Added tests for alias and existing `paths` behavior

## Implementation test
targeting the introduced feat
```bash
pnpm vitest run test/init-script-schema.test.ts
```
or

run the all test suit
```
pnpm test
```