### PR TITLE
fix: replace package name variants during init

### DIFF
--- a/.changeset/package-name-replacement-variants.md
+++ b/.changeset/package-name-replacement-variants.md
@@ -1,0 +1,5 @@
+---
+"create-solana-dapp": patch
+---
+
+Replace package name variants during template initialization.

--- a/src/utils/init-script-rename.ts
+++ b/src/utils/init-script-rename.ts
@@ -7,6 +7,65 @@ import { InitScriptRename } from './init-script-schema'
 import { searchAndReplace } from './search-and-replace'
 import { namesValues } from './vendor/names'
 
+function compareReplacement(fromA: string, fromB: string): number {
+  if (fromA < fromB) {
+    return -1
+  }
+  if (fromA > fromB) {
+    return 1
+  }
+  return 0
+}
+
+function getNameSegments(name: string): string[] {
+  return name
+    .replace(/([a-z\d])([A-Z])/g, '$1 $2')
+    .split(/[^A-Za-z\d]+/)
+    .filter(Boolean)
+}
+
+function toCompactName(name: string): string {
+  return getNameSegments(name).join('').toLowerCase()
+}
+
+function toKebabName(name: string): string {
+  return getNameSegments(name).join('-').toLowerCase()
+}
+
+function toPascalName(name: string): string {
+  return getNameSegments(name)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1).toLowerCase())
+    .join('')
+}
+
+function toSnakeName(name: string): string {
+  return getNameSegments(name).join('_').toLowerCase()
+}
+
+function packageNameReplacementValues(from: string, to: string): { fromNames: string[]; toNames: string[] } {
+  const replacements = new Map<string, string>()
+  const variantReplacements = [
+    [from, to],
+    [toCompactName(from), toCompactName(to)],
+    [toKebabName(from), toKebabName(to)],
+    [toPascalName(from), toPascalName(to)],
+    [toSnakeName(from), toSnakeName(to)],
+  ]
+
+  for (const [fromName, toName] of variantReplacements) {
+    if (fromName && !replacements.has(fromName)) {
+      replacements.set(fromName, toName)
+    }
+  }
+
+  const sortedReplacements = [...replacements.entries()].sort(([fromA], [fromB]) => compareReplacement(fromA, fromB))
+
+  return {
+    fromNames: sortedReplacements.map(([fromName]) => fromName),
+    toNames: sortedReplacements.map(([, toName]) => toName),
+  }
+}
+
 export async function initScriptRename(args: GetArgsResult, rename?: InitScriptRename, verbose = false) {
   const tag = `initScriptRename`
   const { contents } = getPackageJson(args.targetDirectory)
@@ -15,7 +74,8 @@ export async function initScriptRename(args: GetArgsResult, rename?: InitScriptR
     if (args.verbose) {
       log.warn(`${tag}: renaming template name '${contents.name}' to project name '${args.name}'`)
     }
-    await searchAndReplace(args.targetDirectory, [contents.name], [args.name], false, verbose)
+    const { fromNames, toNames } = packageNameReplacementValues(contents.name, args.name)
+    await searchAndReplace(args.targetDirectory, fromNames, toNames, args.dryRun, verbose)
   }
 
   // Return early if there are no renames defined in the init script

--- a/src/utils/search-and-replace.ts
+++ b/src/utils/search-and-replace.ts
@@ -3,6 +3,10 @@ import { join } from 'node:path'
 
 const EXCLUDED_DIRECTORIES = new Set(['dist', 'coverage', 'node_modules', '.git', 'tmp'])
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`)
+}
+
 export async function searchAndReplace(
   rootFolder: string,
   fromStrings: string[],
@@ -20,8 +24,8 @@ export async function searchAndReplace(
       let newContent = content
 
       for (const [i, fromString] of fromStrings.entries()) {
-        const regex = new RegExp(fromString, 'g')
-        newContent = newContent.replace(regex, toStrings[i])
+        const regex = new RegExp(escapeRegExp(fromString), 'g')
+        newContent = newContent.replace(regex, () => toStrings[i])
         // Make sure we maintain the possible newline at the end of the file
         if (content.endsWith('\n') && !newContent.endsWith('\n')) {
           newContent += '\n'
@@ -36,7 +40,7 @@ export async function searchAndReplace(
           console.log(`${isDryRun ? '[Dry Run] ' : ''}File modified: ${filePath}`)
         }
         for (const [index, fromStr] of fromStrings.entries()) {
-          const count = (newContent.match(new RegExp(toStrings[index], 'g')) || []).length
+          const count = (newContent.match(new RegExp(escapeRegExp(toStrings[index]), 'g')) || []).length
           if (count > 0 && isVerbose) {
             console.log(`  Replaced "${fromStr}" with "${toStrings[index]}" ${count} time(s)`)
           }
@@ -96,7 +100,7 @@ export async function searchAndReplace(
         let newName = entry.name
 
         for (const [i, fromString] of fromStrings.entries()) {
-          newName = newName.replace(new RegExp(fromString, 'g'), toStrings[i])
+          newName = newName.replace(new RegExp(escapeRegExp(fromString), 'g'), () => toStrings[i])
         }
 
         const newPath = join(directoryPath, newName)

--- a/test/init-script-rename.test.ts
+++ b/test/init-script-rename.test.ts
@@ -19,7 +19,7 @@ vi.mock('@clack/prompts', () => ({
 }))
 
 describe('initScriptRename', () => {
-  const packageJsonName = 'template-project'
+  const packageJsonName = 'foo-bar'
 
   const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
@@ -50,11 +50,31 @@ describe('initScriptRename', () => {
   }
 
   it('should rename the project based on package.json name', async () => {
-    const args = { ...baseArgs }
+    const args = { ...baseArgs, name: 'my-app' }
 
     await initScriptRename(args)
 
-    expect(searchAndReplace).toHaveBeenCalledWith(args.targetDirectory, [packageJsonName], [args.name], false, false)
+    expect(searchAndReplace).toHaveBeenCalledWith(
+      args.targetDirectory,
+      ['FooBar', 'foo-bar', 'foo_bar', 'foobar'],
+      ['MyApp', 'my-app', 'my_app', 'myapp'],
+      false,
+      false,
+    )
+  })
+
+  it('should use dry run mode when replacing the project name from package.json', async () => {
+    const args = { ...baseArgs, dryRun: true }
+
+    await initScriptRename(args)
+
+    expect(searchAndReplace).toHaveBeenCalledWith(
+      args.targetDirectory,
+      expect.any(Array),
+      expect.any(Array),
+      true,
+      false,
+    )
   })
 
   it('should return early if no rename object is provided', async () => {

--- a/test/search-and-replace.test.ts
+++ b/test/search-and-replace.test.ts
@@ -55,6 +55,17 @@ describe('searchAndReplace', () => {
     await expect(access(join(tempDir, 'oldname.txt'))).rejects.toThrow()
   })
 
+  it('should treat search values as literal strings', async () => {
+    await writeFile(join(tempDir, 'foo.bar.txt'), 'foo.bar fooXbar')
+    await writeFile(join(tempDir, 'fooXbar.txt'), 'fooXbar')
+
+    await searchAndReplace(tempDir, ['foo.bar'], ['baz'], false, false)
+
+    expect(await readFile(join(tempDir, 'baz.txt'), 'utf8')).toBe('baz fooXbar')
+    expect(await readFile(join(tempDir, 'fooXbar.txt'), 'utf8')).toBe('fooXbar')
+    await expect(access(join(tempDir, 'foo.bar.txt'))).rejects.toThrow()
+  })
+
   it('should exclude directories like node_modules and .git from processing', async () => {
     const consoleLogSpy = vi.spyOn(console, 'log')
 


### PR DESCRIPTION
Generate package-name replacement variants for kebab, snake, Pascal, and compact forms before applying the template rename.

Treat search strings as literals, honor dry-run mode for package name replacement, and add a patch changeset.
