### PR TITLE
fix: show all mobile templates

### DIFF
--- a/.changeset/mobile-template-filter.md
+++ b/.changeset/mobile-template-filter.md
@@ -1,0 +1,5 @@
+---
+'create-solana-dapp': patch
+---
+
+Show all Solana Mobile templates in the mobile template prompt.

--- a/src/utils/get-menu-config.ts
+++ b/src/utils/get-menu-config.ts
@@ -11,10 +11,10 @@ export function getMenuConfig(): MenuConfig {
       name: 'Kit Framework',
     },
     {
-      description: 'Solana Mobile Templates based on Expo',
+      description: 'Solana Mobile Templates',
       groups: ['mobile'],
       id: 'solana-mobile',
-      keywords: ['expo'],
+      keywords: [],
       name: 'Solana Mobile',
     },
     {


### PR DESCRIPTION
Remove the Expo-only keyword filter from the Solana Mobile menu so native mobile templates such as kotlin-compose are selectable.

Add a patch changeset for the CLI prompt behavior.

In preparation for https://github.com/solana-foundation/templates/pull/409 