### PR TITLE
fix: pass GitHub token to canary version

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -98,6 +98,8 @@ jobs:
 
       - name: Create canary version
         run: pnpm changeset version --snapshot canary
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Validate package
         run: pnpm exec publint --pack pnpm


### PR DESCRIPTION
Expose the workflow GITHUB_TOKEN to the canary changeset version step so the GitHub changelog plugin can resolve release metadata.
