### PR TITLE
fix: rename init display names

### DIFF
--- a/.changeset/display-name-init-rename.md
+++ b/.changeset/display-name-init-rename.md
@@ -1,0 +1,5 @@
+---
+'create-solana-dapp': patch
+---
+
+Rename spaced init-script display names to the project display name.

--- a/.changeset/skills-init-config.md
+++ b/.changeset/skills-init-config.md
@@ -1,0 +1,5 @@
+---
+'create-solana-dapp': patch
+---
+
+Support template-configured skill installation lists.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ in the project.
         "paths": ["anchor", "src"],
       },
     },
+    // Optional. If omitted, the default Solana dev skill is installed.
+    // Set to [] to skip skill installation, or provide one or more skill repo URLs to replace the default.
+    "skills": ["https://github.com/org/skill-repo"],
     // Check versions and give a warning if it's not installed or the version is lower
     "versions": {
       "adb": "33.0.0",

--- a/src/utils/create-app-task-install-dev-skill.ts
+++ b/src/utils/create-app-task-install-dev-skill.ts
@@ -1,29 +1,67 @@
 import { log } from '@clack/prompts'
 import { GetArgsResult } from './get-args-result'
+import { getPackageJson } from './get-package-json'
+import { initScriptKey } from './init-script-schema'
 import { execAndWait } from './vendor/child-process-utils'
 import { Task } from './vendor/clack-tasks'
+
+const defaultSkills = ['https://github.com/solana-foundation/solana-dev-skill']
 
 export function createAppTaskInstallDevSkill(args: GetArgsResult): Task {
   return {
     enabled: !args.skipInstall,
     task: async (result) => {
-      try {
-        if (args.verbose) {
-          log.warn(`Installing Solana dev skill`)
-        }
-        await execAndWait(
-          'npx -y skills add https://github.com/solana-foundation/solana-dev-skill --skill "*" -y',
-          args.targetDirectory,
-        )
-        return result({ message: 'Installed Solana dev skill' })
-      } catch (error) {
-        if (args.verbose) {
-          log.error(`Error installing Solana dev skill: ${error}`)
-        }
-        // Non-fatal: skip if it fails
-        return result({ message: 'Skipped Solana dev skill installation' })
+      const { contents } = getPackageJson(args.targetDirectory)
+      const skills = contents[initScriptKey]?.skills ?? defaultSkills
+
+      if (skills.length === 0) {
+        return result({ message: 'Skipped skill installation' })
       }
+
+      const installed = await installSkills(args, skills)
+
+      if (installed === 0) {
+        return result({ message: 'Failed to install skills' })
+      }
+
+      if (installed < skills.length) {
+        return result({ message: `Installed ${installed}/${skills.length} skills` })
+      }
+
+      return result({ message: `Installed ${skills.length === 1 ? 'skill' : 'skills'}` })
     },
-    title: 'Installing Solana dev skill',
+    title: 'Installing skills',
   }
+}
+
+async function installSkills(args: GetArgsResult, skills: string[]) {
+  const installs: boolean[] = []
+  for (const skill of skills) {
+    installs.push(await installSkill(args, skill))
+  }
+  return installs.filter(Boolean).length
+}
+
+async function installSkill(args: GetArgsResult, skill: string) {
+  try {
+    if (args.verbose) {
+      log.warn(`Installing skill ${skill}`)
+    }
+
+    await execAndWait(`npx -y skills add ${shellQuote(skill)} --skill "*" -y`, args.targetDirectory)
+    return true
+  } catch (error) {
+    if (args.verbose) {
+      log.error(`Error installing skill ${skill}: ${error}`)
+    }
+    return false
+  }
+}
+
+function shellQuote(value: string) {
+  if (process.platform === 'win32') {
+    return `"${value.replaceAll('"', '""')}"`
+  }
+
+  return `'${value.replaceAll("'", String.raw`'\''`)}'`
 }

--- a/src/utils/create-app.ts
+++ b/src/utils/create-app.ts
@@ -18,10 +18,10 @@ export async function createApp(args: CreateAppArgs): Promise<CreateAppResult> {
     createAppTaskInstallDependencies(args),
     // Run the (optional) setup script defined in package.json (e.g. build anchor program)
     createAppTaskRunSetup(args),
+    // Install skills for AI coding agents
+    createAppTaskInstallDevSkill(args),
     // Run the (optional) init script defined in package.json
     createAppTaskRunInitScript(args),
-    // Install the Solana dev skill for AI coding agents
-    createAppTaskInstallDevSkill(args),
     // Initialize git repository
     createAppTaskInitializeGit(args),
   ])

--- a/src/utils/init-script-rename.ts
+++ b/src/utils/init-script-rename.ts
@@ -28,6 +28,12 @@ function toCompactName(name: string): string {
   return getNameSegments(name).join('').toLowerCase()
 }
 
+function toDisplayName(name: string): string {
+  return getNameSegments(name)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1).toLowerCase())
+    .join(' ')
+}
+
 function toKebabName(name: string): string {
   return getNameSegments(name).join('-').toLowerCase()
 }
@@ -66,6 +72,21 @@ function packageNameReplacementValues(from: string, to: string): { fromNames: st
   }
 }
 
+function initScriptRenameReplacementValues(from: string, to: string): { fromNames: string[]; toNames: string[] } {
+  const fromNames = namesValues(from)
+  let toNames = namesValues(to)
+
+  if (/\s/.test(from)) {
+    const displayName = toDisplayName(to)
+    const displayIndex = fromNames.indexOf(from)
+    if (displayIndex !== -1) {
+      toNames = toNames.map((toName, index) => (index === displayIndex ? displayName : toName))
+    }
+  }
+
+  return { fromNames, toNames }
+}
+
 export async function initScriptRename(args: GetArgsResult, rename?: InitScriptRename, verbose = false) {
   const tag = `initScriptRename`
   const { contents } = getPackageJson(args.targetDirectory)
@@ -100,8 +121,7 @@ export async function initScriptRename(args: GetArgsResult, rename?: InitScriptR
     const to = rename[from].to.replace('{{name}}', args.name)
 
     // Get the name matrix for the 'from' and the 'to' value
-    const fromNames = namesValues(from)
-    const toNames = namesValues(to)
+    const { fromNames, toNames } = initScriptRenameReplacementValues(from, to)
 
     for (const path of rename[from].paths) {
       const targetPath = join(args.targetDirectory, path)

--- a/src/utils/init-script-schema.ts
+++ b/src/utils/init-script-schema.ts
@@ -5,6 +5,8 @@ export const initScriptKey = 'create-solana-dapp'
 
 export const InitScriptSchemaInstructions = z.array(z.string())
 
+export const InitScriptSchemaSkills = z.array(z.string())
+
 export const InitScriptSchemaVersions = z.object({
   adb: z.string().optional(),
   anchor: z.string().optional(),
@@ -22,9 +24,11 @@ export const InitScriptSchemaRename = z.record(
 export const InitScriptSchema = z.object({
   instructions: InitScriptSchemaInstructions.optional(),
   rename: InitScriptSchemaRename.optional(),
+  skills: InitScriptSchemaSkills.optional(),
   versions: InitScriptSchemaVersions.optional(),
 })
 
 export type InitScriptInstructions = z.infer<typeof InitScriptSchemaInstructions>
 export type InitScriptRename = z.infer<typeof InitScriptSchemaRename>
+export type InitScriptSkills = z.infer<typeof InitScriptSchemaSkills>
 export type InitScriptVersions = z.infer<typeof InitScriptSchemaVersions>

--- a/test/create-app-task-install-dev-skill.test.ts
+++ b/test/create-app-task-install-dev-skill.test.ts
@@ -1,0 +1,147 @@
+import { log } from '@clack/prompts'
+import { fs, vol } from 'memfs'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createAppTaskInstallDevSkill } from '../src/utils/create-app-task-install-dev-skill'
+import { GetArgsResult } from '../src/utils/get-args-result'
+import { initScriptKey } from '../src/utils/init-script-schema'
+import { execAndWait } from '../src/utils/vendor/child-process-utils'
+
+vi.mock('node:fs')
+vi.mock('../src/utils/vendor/child-process-utils', () => ({
+  execAndWait: vi.fn(),
+}))
+vi.mock('@clack/prompts', () => ({
+  log: {
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}))
+
+describe('createAppTaskInstallDevSkill', () => {
+  const targetDirectory = '/template'
+  const packageJsonPath = `${targetDirectory}/package.json`
+
+  const baseArgs: GetArgsResult = {
+    app: { name: 'test-app', version: '1.0.0' },
+    dryRun: false,
+    name: 'test-project',
+    packageManager: 'npm',
+    skipGit: false,
+    skipInit: false,
+    skipInstall: false,
+    targetDirectory,
+    template: { description: 'description', name: 'basic', repository: '/template' },
+    verbose: false,
+  }
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vol.reset()
+    fs.mkdirSync(targetDirectory, { recursive: true })
+    vi.mocked(execAndWait).mockResolvedValue({ code: 0, stdout: '' })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should install the default skill when skills is not set', async () => {
+    writePackageJson()
+
+    const result = await runTask()
+
+    expect(result).toEqual({ message: 'Installed skill' })
+    expect(execAndWait).toHaveBeenCalledWith(
+      `npx -y skills add 'https://github.com/solana-foundation/solana-dev-skill' --skill "*" -y`,
+      targetDirectory,
+    )
+  })
+
+  it('should install configured skills instead of the default skill', async () => {
+    writePackageJson({
+      skills: ['https://github.com/example/alpha-skill', 'https://github.com/example/beta-skill'],
+    })
+
+    const result = await runTask()
+
+    expect(result).toEqual({ message: 'Installed skills' })
+    expect(execAndWait).toHaveBeenCalledTimes(2)
+    expect(execAndWait).toHaveBeenNthCalledWith(
+      1,
+      `npx -y skills add 'https://github.com/example/alpha-skill' --skill "*" -y`,
+      targetDirectory,
+    )
+    expect(execAndWait).toHaveBeenNthCalledWith(
+      2,
+      `npx -y skills add 'https://github.com/example/beta-skill' --skill "*" -y`,
+      targetDirectory,
+    )
+  })
+
+  it('should skip skill installation when skills is empty', async () => {
+    writePackageJson({ skills: [] })
+
+    const result = await runTask()
+
+    expect(result).toEqual({ message: 'Skipped skill installation' })
+    expect(execAndWait).not.toHaveBeenCalled()
+  })
+
+  it('should continue after a skill install fails', async () => {
+    writePackageJson({
+      skills: ['https://github.com/example/alpha-skill', 'https://github.com/example/beta-skill'],
+    })
+    vi.mocked(execAndWait).mockRejectedValueOnce(new Error('install failed'))
+
+    const result = await runTask({ ...baseArgs, verbose: true })
+
+    expect(result).toEqual({ message: 'Installed 1/2 skills' })
+    expect(execAndWait).toHaveBeenCalledTimes(2)
+    expect(log.error).toHaveBeenCalledWith(
+      'Error installing skill https://github.com/example/alpha-skill: Error: install failed',
+    )
+  })
+
+  it('should report when all skill installs fail', async () => {
+    writePackageJson({
+      skills: ['https://github.com/example/alpha-skill', 'https://github.com/example/beta-skill'],
+    })
+    vi.mocked(execAndWait).mockRejectedValue(new Error('install failed'))
+
+    const result = await runTask()
+
+    expect(result).toEqual({ message: 'Failed to install skills' })
+  })
+
+  it('should use Windows-compatible quotes on Windows', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    writePackageJson()
+
+    await runTask()
+
+    expect(execAndWait).toHaveBeenCalledWith(
+      `npx -y skills add "https://github.com/solana-foundation/solana-dev-skill" --skill "*" -y`,
+      targetDirectory,
+    )
+  })
+
+  it('should disable the task when install is skipped', () => {
+    const task = createAppTaskInstallDevSkill({ ...baseArgs, skipInstall: true })
+
+    expect(task.enabled).toBe(false)
+  })
+
+  async function runTask(args = baseArgs) {
+    return createAppTaskInstallDevSkill(args).task((value) => value)
+  }
+
+  function writePackageJson(init?: unknown) {
+    fs.writeFileSync(
+      packageJsonPath,
+      JSON.stringify({
+        ...(init === undefined ? {} : { [initScriptKey]: init }),
+        name: 'my-app',
+      }),
+    )
+  }
+})

--- a/test/init-script-rename.test.ts
+++ b/test/init-script-rename.test.ts
@@ -63,6 +63,54 @@ describe('initScriptRename', () => {
     )
   })
 
+  it('should rename spaced display names to project display names', async () => {
+    const args = { ...baseArgs, name: 'my-unicorn2' }
+    const fromNames = ['ExampleApp', 'EXAMPLE_APP', 'example-app', 'Example App', 'exampleApp']
+    const rename = {
+      'Example App': {
+        paths: ['app.json'],
+        to: '{{name}}',
+      },
+    }
+    const toNames = ['MyUnicorn2', 'MY_UNICORN2', 'my-unicorn2', 'my-unicorn2', 'myUnicorn2']
+    vi.mocked(namesValues).mockImplementation((name) => (name === 'Example App' ? fromNames : toNames))
+    vi.mocked(ensureTargetPath).mockResolvedValue(true)
+
+    await initScriptRename(args, rename)
+
+    expect(searchAndReplace).toHaveBeenLastCalledWith(
+      '/template/app.json',
+      fromNames,
+      ['MyUnicorn2', 'MY_UNICORN2', 'my-unicorn2', 'My Unicorn2', 'myUnicorn2'],
+      false,
+      false,
+    )
+  })
+
+  it('should rename spaced display names using the real names output', async () => {
+    const args = { ...baseArgs, name: 'my-unicorn2' }
+    const { namesValues: actualNamesValues } =
+      await vi.importActual<typeof import('../src/utils/vendor/names')>('../src/utils/vendor/names')
+    const rename = {
+      'Example App': {
+        paths: ['app.json'],
+        to: '{{name}}',
+      },
+    }
+    vi.mocked(namesValues).mockImplementation(actualNamesValues)
+    vi.mocked(ensureTargetPath).mockResolvedValue(true)
+
+    await initScriptRename(args, rename)
+
+    expect(searchAndReplace).toHaveBeenLastCalledWith(
+      '/template/app.json',
+      ['ExampleApp', 'EXAMPLE_APP', 'example-app', 'Example App', 'exampleApp'],
+      ['MyUnicorn2', 'MY_UNICORN2', 'my-unicorn2', 'My Unicorn2', 'myUnicorn2'],
+      false,
+      false,
+    )
+  })
+
   it('should use dry run mode when replacing the project name from package.json', async () => {
     const args = { ...baseArgs, dryRun: true }
 


### PR DESCRIPTION
Map spaced init-script rename entries to the generated project display name while preserving existing code and file name variants.

Add a unit test covering generic display-name replacement and a patch changeset for the CLI package.