### PR TITLE
feat: expose embeddable API surface

### DIFF
--- a/.changeset/embeddable-api-surface.md
+++ b/.changeset/embeddable-api-surface.md
@@ -1,0 +1,5 @@
+---
+'create-solana-dapp': minor
+---
+
+Expose embeddable create flow and argument parsing APIs from the package root, and parse `--templates-url` values correctly.

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,32 @@ import { getAppInfo } from './utils/get-app-info'
 import { getArgs } from './utils/get-args'
 import { detectInvokedPackageManager } from './utils/vendor/package-manager'
 
+export { createApp } from './utils/create-app'
+export type { CreateAppArgs, CreateAppResult } from './utils/create-app'
+export { fetchTemplateData } from './utils/fetch-template-data'
+export type { FetchTemplateDataArgs, FetchTemplateDataResult } from './utils/fetch-template-data'
+export { finalNote } from './utils/final-note'
+export type { FinalNoteArgs } from './utils/final-note'
+export { getAppInfo } from './utils/get-app-info'
+export type { AppInfo } from './utils/get-app-info'
+export { getArgs } from './utils/get-args'
+export type { GetArgsResult } from './utils/get-args-result'
+export { listTemplateIds } from './utils/list-template-ids'
+export { listTemplates } from './utils/list-templates'
+export { listVersions } from './utils/list-versions'
+export type { Template } from './utils/template'
+export type {
+  MenuConfig,
+  MenuConfigItem,
+  MenuItem,
+  TemplateJson,
+  TemplateJsonGroup,
+  TemplateJsonTemplate,
+} from './utils/template-schema'
+export { validateProjectName } from './utils/validate-project-name'
+export { detectInvokedPackageManager } from './utils/vendor/package-manager'
+export type { PackageManager } from './utils/vendor/package-manager'
+
 export async function main(argv: string[]) {
   // Get the invoked package manager
   const pm = detectInvokedPackageManager()

--- a/src/utils/create-app.ts
+++ b/src/utils/create-app.ts
@@ -4,10 +4,13 @@ import { createAppTaskInstallDependencies } from './create-app-task-install-depe
 import { createAppTaskInstallDevSkill } from './create-app-task-install-dev-skill'
 import { createAppTaskRunInitScript } from './create-app-task-run-init-script'
 import { createAppTaskRunSetup } from './create-app-task-run-setup'
-import { GetArgsResult } from './get-args-result'
+import { type GetArgsResult } from './get-args-result'
 import { tasks } from './vendor/clack-tasks'
 
-export async function createApp(args: GetArgsResult) {
+export type CreateAppArgs = GetArgsResult
+export type CreateAppResult = string[]
+
+export async function createApp(args: CreateAppArgs): Promise<CreateAppResult> {
   return tasks([
     // Clone the template to the target directory
     createAppTaskCloneTemplate(args),

--- a/src/utils/fetch-template-data.ts
+++ b/src/utils/fetch-template-data.ts
@@ -3,18 +3,22 @@ import { getTemplateGroupsFromUrl } from './get-template-groups-from-url'
 import { getTemplatesFromItems } from './get-templates-from-items'
 import { MenuConfig, MenuItem, TemplateJsonTemplate } from './template-schema'
 
+export interface FetchTemplateDataArgs {
+  config: MenuConfig
+  url: string
+  verbose: boolean
+}
+
+export interface FetchTemplateDataResult {
+  items: MenuItem[]
+  templates: TemplateJsonTemplate[]
+}
+
 export async function fetchTemplateData({
   config,
   url,
   verbose,
-}: {
-  config: MenuConfig
-  url: string
-  verbose: boolean
-}): Promise<{
-  items: MenuItem[]
-  templates: TemplateJsonTemplate[]
-}> {
+}: FetchTemplateDataArgs): Promise<FetchTemplateDataResult> {
   const groups = await getTemplateGroupsFromUrl({ url, verbose })
   const items = getMenuItemsFromTemplateGroups({ config, groups, verbose })
   const templates = getTemplatesFromItems({ items, verbose })

--- a/src/utils/get-args.ts
+++ b/src/utils/get-args.ts
@@ -1,5 +1,5 @@
 import { intro, log, outro } from '@clack/prompts'
-import { program } from 'commander'
+import { Command } from 'commander'
 import * as process from 'node:process'
 import { fetchTemplateData } from './fetch-template-data'
 import { findTemplate } from './find-template'
@@ -19,7 +19,7 @@ const minimalTemplateName = 'nextjs-anchor'
 
 export async function getArgs(argv: string[], app: AppInfo, pm: PackageManager = 'npm'): Promise<GetArgsResult> {
   // Get the result from the command line
-  const input = program
+  const input = new Command()
     .name(app.name)
     .version(app.version, '-V, --version', help('Output the version number'))
     .argument('[name]', 'Name of the project (default: <prompt>)')
@@ -37,7 +37,7 @@ export async function getArgs(argv: string[], app: AppInfo, pm: PackageManager =
     .option('--skip-init', help('Skip running the init script'))
     .option('--skip-install', help('Skip installing dependencies'))
     .option('--skip-version-check', help('Skip checking for CLI updates (not recommended)'))
-    .option('--templates-url', help('Url to templates.json'), getTemplatesUrl())
+    .option('--templates-url <url>', help('Url to templates.json'), getTemplatesUrl())
     .option('-v, --verbose', help('Verbose output (default: false)'))
     .helpOption('-h, --help', help('Display help for command'))
     .addHelpText(

--- a/test/get-args.test.ts
+++ b/test/get-args.test.ts
@@ -1,0 +1,119 @@
+import { intro, log, outro } from '@clack/prompts'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fetchTemplateData } from '../src/utils/fetch-template-data'
+import { getArgs } from '../src/utils/get-args'
+import { getPrompts } from '../src/utils/get-prompts'
+import { runVersionCheck } from '../src/utils/run-version-check'
+import type { Template } from '../src/utils/template'
+import type { TemplateJsonTemplate } from '../src/utils/template-schema'
+
+vi.mock('@clack/prompts', () => ({
+  intro: vi.fn(),
+  log: {
+    error: vi.fn(),
+    success: vi.fn(),
+    warn: vi.fn(),
+    warning: vi.fn(),
+  },
+  outro: vi.fn(),
+}))
+
+vi.mock('../src/utils/fetch-template-data', () => ({
+  fetchTemplateData: vi.fn(),
+}))
+
+vi.mock('../src/utils/get-prompts', () => ({
+  getPrompts: vi.fn(),
+}))
+
+vi.mock('../src/utils/run-version-check', () => ({
+  runVersionCheck: vi.fn(),
+}))
+
+const app = { name: 'create-solana-dapp', version: '0.0.0' }
+const template: TemplateJsonTemplate = {
+  description: 'Basic template',
+  id: 'gh:solana-foundation/templates/basic',
+  keywords: [],
+  name: 'basic',
+  path: 'kit/basic',
+}
+
+describe('getArgs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(fetchTemplateData).mockResolvedValue({ items: [], templates: [template] })
+    vi.mocked(getPrompts).mockResolvedValue({})
+  })
+
+  it('parses --templates-url as a URL value instead of a positional argument', async () => {
+    let promptName = ''
+    let promptTemplate: Template | undefined
+    const url = 'https://example.com/templates.json'
+    vi.mocked(getPrompts).mockImplementation(({ options }) => {
+      promptName = options.name
+      promptTemplate = options.template
+      return Promise.resolve({
+        name: options.name || 'prompted-app',
+      })
+    })
+
+    const args = await getArgs(
+      ['node', 'create-solana-dapp', '--templates-url', url, '--template', 'basic', '--skip-version-check'],
+      app,
+      'pnpm',
+    )
+
+    expect(fetchTemplateData).toHaveBeenCalledWith({
+      config: expect.any(Array),
+      url,
+      verbose: false,
+    })
+    expect(promptName).toBe('')
+    expect(promptTemplate).toBe(template)
+    expect(args.name).toBe('prompted-app')
+    expect(args.targetDirectory).toBe(`${process.cwd()}/prompted-app`)
+    expect(runVersionCheck).not.toHaveBeenCalled()
+  })
+
+  it('keeps existing non-interactive CLI option parsing behavior', async () => {
+    const args = await getArgs(
+      [
+        'node',
+        'create-solana-dapp',
+        'my-app',
+        '--template',
+        'basic',
+        '--pnpm',
+        '--skip-git',
+        '--skip-init',
+        '--skip-install',
+        '--skip-version-check',
+      ],
+      app,
+      'npm',
+    )
+
+    expect(args).toMatchObject({
+      app,
+      dryRun: false,
+      name: 'my-app',
+      packageManager: 'pnpm',
+      skipGit: true,
+      skipInit: true,
+      skipInstall: true,
+      targetDirectory: `${process.cwd()}/my-app`,
+      template,
+      verbose: false,
+    })
+    expect(fetchTemplateData).toHaveBeenCalledWith({
+      config: expect.any(Array),
+      url: expect.stringContaining('templates.json'),
+      verbose: false,
+    })
+    expect(intro).toHaveBeenCalledWith(`${app.name} ${app.version}`)
+    expect(log.error).not.toHaveBeenCalled()
+    expect(outro).not.toHaveBeenCalled()
+    expect(runVersionCheck).not.toHaveBeenCalled()
+  })
+})

--- a/test/root-exports.test.ts
+++ b/test/root-exports.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, expectTypeOf, it } from 'vitest'
+import {
+  createApp,
+  detectInvokedPackageManager,
+  fetchTemplateData,
+  finalNote,
+  getAppInfo,
+  getArgs,
+  listTemplateIds,
+  listTemplates,
+  listVersions,
+  validateProjectName,
+} from '../src/index'
+import type {
+  AppInfo,
+  CreateAppArgs,
+  CreateAppResult,
+  FetchTemplateDataArgs,
+  FetchTemplateDataResult,
+  FinalNoteArgs,
+  GetArgsResult,
+  MenuConfig,
+  MenuConfigItem,
+  MenuItem,
+  PackageManager,
+  Template,
+  TemplateJson,
+  TemplateJsonGroup,
+  TemplateJsonTemplate,
+} from '../src/index'
+
+type PublicApiTypes = {
+  appInfo: AppInfo
+  createAppArgs: CreateAppArgs
+  createAppResult: CreateAppResult
+  fetchTemplateDataArgs: FetchTemplateDataArgs
+  fetchTemplateDataResult: FetchTemplateDataResult
+  finalNoteArgs: FinalNoteArgs
+  getArgsResult: GetArgsResult
+  menuConfig: MenuConfig
+  menuConfigItem: MenuConfigItem
+  menuItem: MenuItem
+  packageManager: PackageManager
+  template: Template
+  templateJson: TemplateJson
+  templateJsonGroup: TemplateJsonGroup
+  templateJsonTemplate: TemplateJsonTemplate
+}
+
+describe('package root exports', () => {
+  it('exports the embeddable API functions', () => {
+    const exportedFunctions = {
+      createApp,
+      detectInvokedPackageManager,
+      fetchTemplateData,
+      finalNote,
+      getAppInfo,
+      getArgs,
+      listTemplateIds,
+      listTemplates,
+      listVersions,
+      validateProjectName,
+    }
+
+    expect(Object.keys(exportedFunctions)).toEqual([
+      'createApp',
+      'detectInvokedPackageManager',
+      'fetchTemplateData',
+      'finalNote',
+      'getAppInfo',
+      'getArgs',
+      'listTemplateIds',
+      'listTemplates',
+      'listVersions',
+      'validateProjectName',
+    ])
+    expect(Object.values(exportedFunctions).every((value) => typeof value === 'function')).toBe(true)
+  })
+
+  it('exports the public API types', () => {
+    expectTypeOf<PublicApiTypes['createAppArgs']>().toEqualTypeOf<PublicApiTypes['getArgsResult']>()
+    expectTypeOf<PublicApiTypes['createAppResult']>().toEqualTypeOf<string[]>()
+    expectTypeOf<PublicApiTypes['fetchTemplateDataArgs']>().toHaveProperty('config')
+    expectTypeOf<PublicApiTypes['fetchTemplateDataResult']>().toHaveProperty('templates')
+  })
+})


### PR DESCRIPTION
Export create flow helpers, argument parsing, and public types from the package root so other CLIs can compose custom flows without importing internals.

Parse --templates-url as a value option and cover root exports plus CLI argument behavior in focused tests.