### PR TITLE
fix: remove stale lockfiles without shell commands

### DIFF
--- a/.changeset/windows-lockfile-cleanup.md
+++ b/.changeset/windows-lockfile-cleanup.md
@@ -1,0 +1,5 @@
+---
+'create-solana-dapp': patch
+---
+
+Delete non-selected package-manager lockfiles without relying on a POSIX shell command.

--- a/src/utils/create-app-task-install-dependencies.ts
+++ b/src/utils/create-app-task-install-dependencies.ts
@@ -1,5 +1,6 @@
 import { log } from '@clack/prompts'
 import { existsSync } from 'node:fs'
+import { rm } from 'node:fs/promises'
 import { join } from 'node:path'
 import { GetArgsResult } from './get-args-result'
 import { execAndWait } from './vendor/child-process-utils'
@@ -25,7 +26,7 @@ export function createAppTaskInstallDependencies(args: GetArgsResult): Task {
         if (args.verbose) {
           log.warn(`Deleting ${lockFile}`)
         }
-        await execAndWait(`rm ${lockFile}`, args.targetDirectory)
+        await rm(join(args.targetDirectory, lockFile), { force: true })
       }
       if (args.verbose) {
         log.warn(`Running ${install}`)

--- a/test/create-app-task-install-dependencies.test.ts
+++ b/test/create-app-task-install-dependencies.test.ts
@@ -1,0 +1,93 @@
+import { existsSync } from 'node:fs'
+import { access, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createAppTaskInstallDependencies } from '../src/utils/create-app-task-install-dependencies'
+import type { GetArgsResult } from '../src/utils/get-args-result'
+import { execAndWait } from '../src/utils/vendor/child-process-utils'
+
+const mockedFs = vi.hoisted(() => ({ disappearingPath: undefined as string | undefined }))
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>()
+  return {
+    ...actual,
+    existsSync: vi.fn((path) => path === mockedFs.disappearingPath || actual.existsSync(path)),
+  }
+})
+
+vi.mock('../src/utils/vendor/child-process-utils', () => ({
+  execAndWait: vi.fn().mockResolvedValue({ code: 0, stdout: '' }),
+}))
+
+const temporaryDirectories: string[] = []
+
+afterEach(async () => {
+  mockedFs.disappearingPath = undefined
+  vi.clearAllMocks()
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { force: true, recursive: true })))
+})
+
+describe('createAppTaskInstallDependencies', () => {
+  it('removes lockfiles from other package managers without a shell command', async () => {
+    const targetDirectory = await mkdtemp(join(tmpdir(), 'create-solana-dapp-install-'))
+    temporaryDirectories.push(targetDirectory)
+    const selectedLockFile = join(targetDirectory, 'package-lock.json')
+    const staleLockFile = join(targetDirectory, 'pnpm-lock.yaml')
+    await Promise.all([writeFile(selectedLockFile, ''), writeFile(staleLockFile, '')])
+
+    const task = createAppTaskInstallDependencies({
+      packageManager: 'npm',
+      skipInstall: false,
+      targetDirectory,
+      verbose: false,
+    } as GetArgsResult)
+
+    await task.task((value) => value)
+
+    expect(existsSync(selectedLockFile)).toBe(true)
+    expect(existsSync(staleLockFile)).toBe(false)
+    expect(execAndWait).toHaveBeenCalledOnce()
+    expect(execAndWait).toHaveBeenCalledWith(expect.stringMatching(/^npm install /), targetDirectory)
+  })
+
+  it('continues installation when a stale lockfile disappears before removal', async () => {
+    const targetDirectory = await mkdtemp(join(tmpdir(), 'create-solana-dapp-install-'))
+    temporaryDirectories.push(targetDirectory)
+    const selectedLockFile = join(targetDirectory, 'package-lock.json')
+    const staleLockFile = join(targetDirectory, 'pnpm-lock.yaml')
+    await writeFile(selectedLockFile, '')
+    mockedFs.disappearingPath = staleLockFile
+
+    const task = createAppTaskInstallDependencies({
+      packageManager: 'npm',
+      skipInstall: false,
+      targetDirectory,
+      verbose: false,
+    } as GetArgsResult)
+
+    await task.task((value) => value)
+
+    await expect(access(selectedLockFile)).resolves.toBeUndefined()
+    await expect(access(staleLockFile)).rejects.toThrow()
+    expect(execAndWait).toHaveBeenCalledOnce()
+    expect(execAndWait).toHaveBeenCalledWith(expect.stringMatching(/^npm install /), targetDirectory)
+  })
+
+  it('does not suppress unexpected lockfile removal errors', async () => {
+    const targetDirectory = await mkdtemp(join(tmpdir(), 'create-solana-dapp-install-'))
+    temporaryDirectories.push(targetDirectory)
+    await mkdir(join(targetDirectory, 'pnpm-lock.yaml'))
+
+    const task = createAppTaskInstallDependencies({
+      packageManager: 'npm',
+      skipInstall: false,
+      targetDirectory,
+      verbose: false,
+    } as GetArgsResult)
+
+    await expect(task.task((value) => value)).rejects.toThrow()
+    expect(execAndWait).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

- remove lockfiles for non-selected package managers with the Node.js filesystem API
- preserve the selected package manager's lockfile
- cover cleanup without routing filenames through a shell command

## Problem

The dependency-install task currently removes stale lockfiles by running `rm <lockfile>` through `child_process.exec`. On Windows, Node.js uses `cmd.exe` by default, where `rm` is unavailable, so project generation fails before installing dependencies when a template includes another package manager's lockfile.

## Fix

Remove each stale lockfile directly with `node:fs/promises` and its joined absolute path. Dependency installation still uses the existing subprocess helper, while lockfile cleanup is now shell-independent.

The regression test verifies that the selected npm lockfile is preserved, a stale pnpm lockfile is removed, and only the npm installation command reaches the subprocess helper.

## Testing

- `pnpm exec vitest run test/create-app-task-install-dependencies.test.ts`
- `pnpm lint`
- `pnpm test:types`
- Windows-safe full suite: 63/63 tests passed
- `pnpm build`
- `pnpm exec publint`

The complete Windows test run executes the new regression successfully and retains the same eight baseline failures in three existing test files that hard-code POSIX path separators. CI runs the suite on Linux, where those existing assertions match the platform.
