### PR TITLE
feat: support template-configured package managers

### DIFF
--- a/.changeset/template-package-manager.md
+++ b/.changeset/template-package-manager.md
@@ -1,0 +1,5 @@
+---
+'create-solana-dapp': patch
+---
+
+Allow templates to require an installed package manager.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ in the project.
       // Adding a '+' will make the line bold and '{pm}' is replaced with the package manager
       "+{pm} run anchor build | test | localnet | deploy",
     ],
+    // Optional. Force this template to use an installed package manager.
+    // An explicitly selected different package manager will stop installation.
+    "packageManager": "bun",
     // Rename is a map of terms to rename
     "rename": {
       // Rename every instance of counter

--- a/src/utils/create-app.ts
+++ b/src/utils/create-app.ts
@@ -5,24 +5,33 @@ import { createAppTaskInstallDevSkill } from './create-app-task-install-dev-skil
 import { createAppTaskRunInitScript } from './create-app-task-run-init-script'
 import { createAppTaskRunSetup } from './create-app-task-run-setup'
 import { type GetArgsResult } from './get-args-result'
+import { initScriptPackageManager } from './init-script-package-manager'
 import { tasks } from './vendor/clack-tasks'
 
 export type CreateAppArgs = GetArgsResult
 export type CreateAppResult = string[]
 
 export async function createApp(args: CreateAppArgs): Promise<CreateAppResult> {
-  return tasks([
+  const instructions = await tasks([
     // Clone the template to the target directory
     createAppTaskCloneTemplate(args),
-    // Install the dependencies
-    createAppTaskInstallDependencies(args),
-    // Run the (optional) setup script defined in package.json (e.g. build anchor program)
-    createAppTaskRunSetup(args),
-    // Install skills for AI coding agents
-    createAppTaskInstallDevSkill(args),
-    // Run the (optional) init script defined in package.json
-    createAppTaskRunInitScript(args),
-    // Initialize git repository
-    createAppTaskInitializeGit(args),
   ])
+
+  initScriptPackageManager(args)
+
+  return [
+    ...instructions,
+    ...(await tasks([
+      // Install the dependencies
+      createAppTaskInstallDependencies(args),
+      // Run the (optional) setup script defined in package.json (e.g. build anchor program)
+      createAppTaskRunSetup(args),
+      // Install skills for AI coding agents
+      createAppTaskInstallDevSkill(args),
+      // Run the (optional) init script defined in package.json
+      createAppTaskRunInitScript(args),
+      // Initialize git repository
+      createAppTaskInitializeGit(args),
+    ])),
+  ]
 }

--- a/src/utils/get-args-result.ts
+++ b/src/utils/get-args-result.ts
@@ -7,6 +7,7 @@ export interface GetArgsResult {
   dryRun: boolean
   name: string
   packageManager: PackageManager
+  packageManagerExplicit?: boolean
   skipGit: boolean
   skipInit: boolean
   skipInstall: boolean

--- a/src/utils/get-args.ts
+++ b/src/utils/get-args.ts
@@ -79,6 +79,7 @@ Examples:
     process.exit(0)
   }
   let packageManager = result.packageManager ?? pm
+  const packageManagerExplicit = Boolean(result.packageManager || result.pnpm || result.yarn || result.bun)
 
   // The 'yarn', 'pnpm' and 'bun' options are mutually exclusive and will override the 'packageManager' option
   const managers = [result.pnpm && 'pnpm', result.yarn && 'yarn', result.bun && 'bun'].filter(Boolean)
@@ -124,6 +125,7 @@ Examples:
     dryRun: result.dryRun ?? false,
     name: name ?? '',
     packageManager,
+    packageManagerExplicit,
     skipGit: result.skipGit ?? false,
     skipInit: result.skipInit ?? false,
     skipInstall: result.skipInstall ?? false,

--- a/src/utils/init-script-package-manager.ts
+++ b/src/utils/init-script-package-manager.ts
@@ -1,0 +1,28 @@
+import { GetArgsResult } from './get-args-result'
+import { getPackageJson } from './get-package-json'
+import { initScriptKey } from './init-script-schema'
+import { taskFail } from './vendor/clack-tasks'
+import { getPackageManagerVersion } from './vendor/package-manager'
+
+export function initScriptPackageManager(args: GetArgsResult): void {
+  const { contents } = getPackageJson(args.targetDirectory)
+  const packageManager = contents[initScriptKey]?.packageManager
+
+  if (!packageManager) {
+    return
+  }
+
+  if ((args.packageManagerExplicit ?? true) && args.packageManager !== packageManager) {
+    taskFail(`Template requires ${packageManager}, but ${args.packageManager} was explicitly selected`)
+    return
+  }
+
+  try {
+    getPackageManagerVersion(packageManager, args.targetDirectory)
+  } catch {
+    taskFail(`Template requires ${packageManager}, but ${packageManager} is not installed`)
+    return
+  }
+
+  args.packageManager = packageManager
+}

--- a/src/utils/init-script-schema.ts
+++ b/src/utils/init-script-schema.ts
@@ -1,9 +1,12 @@
 import { z } from 'zod/v3'
+import { packageManagers } from './vendor/package-manager'
 
 // This is the key used in package.json to store the init script
 export const initScriptKey = 'create-solana-dapp'
 
 export const InitScriptSchemaInstructions = z.array(z.string())
+
+export const InitScriptSchemaPackageManager = z.enum(packageManagers)
 
 export const InitScriptSchemaSkills = z.array(z.string())
 
@@ -23,12 +26,14 @@ export const InitScriptSchemaRename = z.record(
 
 export const InitScriptSchema = z.object({
   instructions: InitScriptSchemaInstructions.optional(),
+  packageManager: InitScriptSchemaPackageManager.optional(),
   rename: InitScriptSchemaRename.optional(),
   skills: InitScriptSchemaSkills.optional(),
   versions: InitScriptSchemaVersions.optional(),
 })
 
 export type InitScriptInstructions = z.infer<typeof InitScriptSchemaInstructions>
+export type InitScriptPackageManager = z.infer<typeof InitScriptSchemaPackageManager>
 export type InitScriptRename = z.infer<typeof InitScriptSchemaRename>
 export type InitScriptSkills = z.infer<typeof InitScriptSchemaSkills>
 export type InitScriptVersions = z.infer<typeof InitScriptSchemaVersions>

--- a/test/create-app.test.ts
+++ b/test/create-app.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp } from '../src/utils/create-app'
+import { createAppTaskInstallDependencies } from '../src/utils/create-app-task-install-dependencies'
+import { GetArgsResult } from '../src/utils/get-args-result'
+import { initScriptPackageManager } from '../src/utils/init-script-package-manager'
+import { tasks } from '../src/utils/vendor/clack-tasks'
+
+vi.mock('../src/utils/create-app-task-install-dependencies', () => ({
+  createAppTaskInstallDependencies: vi.fn((args: GetArgsResult) => ({
+    task: vi.fn(),
+    title: `Installing via ${args.packageManager}`,
+  })),
+}))
+vi.mock('../src/utils/init-script-package-manager', () => ({
+  initScriptPackageManager: vi.fn(),
+}))
+vi.mock('../src/utils/vendor/clack-tasks', () => ({
+  taskFail: vi.fn(),
+  tasks: vi.fn(),
+}))
+
+describe('createApp', () => {
+  const args: GetArgsResult = {
+    app: { name: 'test-app', version: '1.0.0' },
+    dryRun: false,
+    name: 'test-project',
+    packageManager: 'npm',
+    packageManagerExplicit: false,
+    skipGit: false,
+    skipInit: false,
+    skipInstall: false,
+    targetDirectory: '/template',
+    template: { description: 'description', name: 'basic', repository: '/template' },
+    verbose: false,
+  }
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('should resolve the template package manager after cloning and before creating install tasks', async () => {
+    vi.mocked(tasks).mockResolvedValueOnce(['clone instruction']).mockResolvedValueOnce(['remaining instruction'])
+    vi.mocked(initScriptPackageManager).mockImplementation((args) => {
+      args.packageManager = 'bun'
+    })
+
+    const result = await createApp({ ...args })
+
+    expect(vi.mocked(tasks).mock.calls[0][0]).toHaveLength(1)
+    expect(vi.mocked(tasks).mock.calls[0][0][0].title).toBe('Cloning template')
+    expect(initScriptPackageManager).toHaveBeenCalledOnce()
+    expect(createAppTaskInstallDependencies).toHaveBeenCalledWith(expect.objectContaining({ packageManager: 'bun' }))
+    expect(vi.mocked(tasks).mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(initScriptPackageManager).mock.invocationCallOrder[0],
+    )
+    expect(vi.mocked(initScriptPackageManager).mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(createAppTaskInstallDependencies).mock.invocationCallOrder[0],
+    )
+    expect(result).toEqual(['clone instruction', 'remaining instruction'])
+  })
+})

--- a/test/get-args.test.ts
+++ b/test/get-args.test.ts
@@ -72,6 +72,7 @@ describe('getArgs', () => {
     expect(promptName).toBe('')
     expect(promptTemplate).toBe(template)
     expect(args.name).toBe('prompted-app')
+    expect(args.packageManagerExplicit).toBe(false)
     expect(args.targetDirectory).toBe(`${process.cwd()}/prompted-app`)
     expect(runVersionCheck).not.toHaveBeenCalled()
   })
@@ -99,6 +100,7 @@ describe('getArgs', () => {
       dryRun: false,
       name: 'my-app',
       packageManager: 'pnpm',
+      packageManagerExplicit: true,
       skipGit: true,
       skipInit: true,
       skipInstall: true,

--- a/test/init-script-package-manager.test.ts
+++ b/test/init-script-package-manager.test.ts
@@ -1,0 +1,103 @@
+import { fs, vol } from 'memfs'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { GetArgsResult } from '../src/utils/get-args-result'
+import { initScriptPackageManager } from '../src/utils/init-script-package-manager'
+import { initScriptKey } from '../src/utils/init-script-schema'
+import { getPackageManagerVersion } from '../src/utils/vendor/package-manager'
+
+vi.mock('node:fs')
+vi.mock('../src/utils/vendor/package-manager', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../src/utils/vendor/package-manager')>()),
+  getPackageManagerVersion: vi.fn(),
+}))
+vi.mock('@clack/prompts', () => ({
+  log: {
+    error: vi.fn(),
+  },
+}))
+
+describe('initScriptPackageManager', () => {
+  const targetDirectory = '/template'
+  const packageJsonPath = `${targetDirectory}/package.json`
+
+  const baseArgs: GetArgsResult = {
+    app: { name: 'test-app', version: '1.0.0' },
+    dryRun: false,
+    name: 'test-project',
+    packageManager: 'npm',
+    packageManagerExplicit: false,
+    skipGit: false,
+    skipInit: false,
+    skipInstall: false,
+    targetDirectory,
+    template: { description: 'description', name: 'basic', repository: '/template' },
+    verbose: false,
+  }
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vol.reset()
+    fs.mkdirSync(targetDirectory, { recursive: true })
+    vi.mocked(getPackageManagerVersion).mockReturnValue('1.2.3')
+  })
+
+  it('should keep the selected package manager when the template does not require one', () => {
+    writePackageJson()
+    const args = { ...baseArgs }
+
+    initScriptPackageManager(args)
+
+    expect(args.packageManager).toBe('npm')
+    expect(getPackageManagerVersion).not.toHaveBeenCalled()
+  })
+
+  it('should override the invoked package manager with the template requirement', () => {
+    writePackageJson('bun')
+    const args = { ...baseArgs }
+
+    initScriptPackageManager(args)
+
+    expect(args.packageManager).toBe('bun')
+    expect(getPackageManagerVersion).toHaveBeenCalledWith('bun', targetDirectory)
+  })
+
+  it('should allow explicitly selecting the package manager required by the template', () => {
+    writePackageJson('bun')
+    const args = { ...baseArgs, packageManager: 'bun' as const, packageManagerExplicit: true }
+
+    initScriptPackageManager(args)
+
+    expect(args.packageManager).toBe('bun')
+    expect(getPackageManagerVersion).toHaveBeenCalledWith('bun', targetDirectory)
+  })
+
+  it('should reject an explicitly selected package manager that conflicts with the template', () => {
+    writePackageJson('bun')
+    const args = { ...baseArgs, packageManagerExplicit: true }
+
+    expect(() => initScriptPackageManager(args)).toThrow('Template requires bun, but npm was explicitly selected')
+    expect(args.packageManager).toBe('npm')
+    expect(getPackageManagerVersion).not.toHaveBeenCalled()
+  })
+
+  it('should reject a template package manager that is not installed', () => {
+    writePackageJson('bun')
+    vi.mocked(getPackageManagerVersion).mockImplementation(() => {
+      throw new Error('command not found')
+    })
+    const args = { ...baseArgs }
+
+    expect(() => initScriptPackageManager(args)).toThrow('Template requires bun, but bun is not installed')
+    expect(args.packageManager).toBe('npm')
+  })
+
+  function writePackageJson(packageManager?: string) {
+    fs.writeFileSync(
+      packageJsonPath,
+      JSON.stringify({
+        ...(packageManager ? { [initScriptKey]: { packageManager } } : {}),
+        name: 'my-app',
+      }),
+    )
+  }
+})

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -1,0 +1,67 @@
+import { cancel } from '@clack/prompts'
+import * as process from 'node:process'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { main } from '../src/index'
+import { createApp } from '../src/utils/create-app'
+import { getAppInfo } from '../src/utils/get-app-info'
+import { getArgs } from '../src/utils/get-args'
+
+vi.mock('@clack/prompts', () => ({
+  cancel: vi.fn(),
+  log: {
+    warn: vi.fn(),
+  },
+  note: vi.fn(),
+  outro: vi.fn(),
+}))
+vi.mock('node:process', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('node:process')>()),
+  exit: vi.fn((code) => {
+    throw new Error(`process.exit(${code})`)
+  }),
+}))
+vi.mock('../src/utils/create-app', () => ({
+  createApp: vi.fn(),
+}))
+vi.mock('../src/utils/get-app-info', () => ({
+  getAppInfo: vi.fn(),
+}))
+vi.mock('../src/utils/get-args', () => ({
+  getArgs: vi.fn(),
+}))
+vi.mock('../src/utils/vendor/package-manager', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../src/utils/vendor/package-manager')>()),
+  detectInvokedPackageManager: vi.fn(() => 'npm'),
+}))
+
+describe('main', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getAppInfo).mockReturnValue({ name: 'test-app', version: '1.0.0' })
+    vi.mocked(getArgs).mockResolvedValue({
+      app: { name: 'test-app', version: '1.0.0' },
+      dryRun: false,
+      name: 'test-project',
+      packageManager: 'npm',
+      packageManagerExplicit: false,
+      skipGit: false,
+      skipInit: false,
+      skipInstall: false,
+      targetDirectory: '/template',
+      template: { description: 'description', name: 'basic', repository: '/template' },
+      verbose: false,
+    })
+  })
+
+  it.each([
+    'Template requires bun, but bun is not installed',
+    'Template requires bun, but npm was explicitly selected',
+  ])('should exit with a non-zero code when %s', async (message) => {
+    vi.mocked(createApp).mockRejectedValue(new Error(message))
+
+    await expect(main(['node', 'create-solana-dapp'])).rejects.toThrow('process.exit(1)')
+
+    expect(cancel).toHaveBeenCalledWith(`Error: ${message}`)
+    expect(process.exit).toHaveBeenCalledWith(1)
+  })
+})


### PR DESCRIPTION
Allow templates to require an installed package manager, override invocation-derived selection, and reject explicit conflicts.

Resolve the template requirement before install tasks and preserve instructions across both task phases.