### PR TITLE
fix: improve template package manager diagnostics

### DIFF
--- a/.changeset/package-manager-diagnostics.md
+++ b/.changeset/package-manager-diagnostics.md
@@ -1,0 +1,5 @@
+---
+'create-solana-dapp': patch
+---
+
+Clarify template package-manager availability errors and verbose diagnostics.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ in the project.
         "paths": ["anchor", "src"],
       },
     },
-    // Optional. If omitted, the default Solana dev skill is installed.
+    // Optional. If omitted, the default Solana skill is installed.
     // Set to [] to skip skill installation, or provide one or more skill repo URLs to replace the default.
     "skills": ["https://github.com/org/skill-repo"],
     // Check versions and give a warning if it's not installed or the version is lower

--- a/src/utils/create-app-task-install-skills.ts
+++ b/src/utils/create-app-task-install-skills.ts
@@ -7,7 +7,7 @@ import { Task } from './vendor/clack-tasks'
 
 const defaultSkills = ['https://github.com/solana-foundation/solana-dev-skill']
 
-export function createAppTaskInstallDevSkill(args: GetArgsResult): Task {
+export function createAppTaskInstallSkills(args: GetArgsResult): Task {
   return {
     enabled: !args.skipInstall,
     task: async (result) => {

--- a/src/utils/create-app.ts
+++ b/src/utils/create-app.ts
@@ -1,7 +1,7 @@
 import { createAppTaskCloneTemplate } from './create-app-task-clone-template'
 import { createAppTaskInitializeGit } from './create-app-task-initialize-git'
 import { createAppTaskInstallDependencies } from './create-app-task-install-dependencies'
-import { createAppTaskInstallDevSkill } from './create-app-task-install-dev-skill'
+import { createAppTaskInstallSkills } from './create-app-task-install-skills'
 import { createAppTaskRunInitScript } from './create-app-task-run-init-script'
 import { createAppTaskRunSetup } from './create-app-task-run-setup'
 import { type GetArgsResult } from './get-args-result'
@@ -27,7 +27,7 @@ export async function createApp(args: CreateAppArgs): Promise<CreateAppResult> {
       // Run the (optional) setup script defined in package.json (e.g. build anchor program)
       createAppTaskRunSetup(args),
       // Install skills for AI coding agents
-      createAppTaskInstallDevSkill(args),
+      createAppTaskInstallSkills(args),
       // Run the (optional) init script defined in package.json
       createAppTaskRunInitScript(args),
       // Initialize git repository

--- a/src/utils/get-args-result.ts
+++ b/src/utils/get-args-result.ts
@@ -7,6 +7,7 @@ export interface GetArgsResult {
   dryRun: boolean
   name: string
   packageManager: PackageManager
+  /** Treated as true when omitted by programmatic callers. */
   packageManagerExplicit?: boolean
   skipGit: boolean
   skipInit: boolean

--- a/src/utils/init-script-package-manager.ts
+++ b/src/utils/init-script-package-manager.ts
@@ -1,3 +1,4 @@
+import { log } from '@clack/prompts'
 import { GetArgsResult } from './get-args-result'
 import { getPackageJson } from './get-package-json'
 import { initScriptKey } from './init-script-schema'
@@ -19,8 +20,11 @@ export function initScriptPackageManager(args: GetArgsResult): void {
 
   try {
     getPackageManagerVersion(packageManager, args.targetDirectory)
-  } catch {
-    taskFail(`Template requires ${packageManager}, but ${packageManager} is not installed`)
+  } catch (error) {
+    if (args.verbose) {
+      log.error(`Error checking ${packageManager} availability: ${error}`)
+    }
+    taskFail(`Template requires ${packageManager}, but ${packageManager} is not available`)
     return
   }
 

--- a/test/create-app-task-install-skills.test.ts
+++ b/test/create-app-task-install-skills.test.ts
@@ -1,7 +1,7 @@
 import { log } from '@clack/prompts'
 import { fs, vol } from 'memfs'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createAppTaskInstallDevSkill } from '../src/utils/create-app-task-install-dev-skill'
+import { createAppTaskInstallSkills } from '../src/utils/create-app-task-install-skills'
 import { GetArgsResult } from '../src/utils/get-args-result'
 import { initScriptKey } from '../src/utils/init-script-schema'
 import { execAndWait } from '../src/utils/vendor/child-process-utils'
@@ -17,7 +17,7 @@ vi.mock('@clack/prompts', () => ({
   },
 }))
 
-describe('createAppTaskInstallDevSkill', () => {
+describe('createAppTaskInstallSkills', () => {
   const targetDirectory = '/template'
   const packageJsonPath = `${targetDirectory}/package.json`
 
@@ -126,13 +126,13 @@ describe('createAppTaskInstallDevSkill', () => {
   })
 
   it('should disable the task when install is skipped', () => {
-    const task = createAppTaskInstallDevSkill({ ...baseArgs, skipInstall: true })
+    const task = createAppTaskInstallSkills({ ...baseArgs, skipInstall: true })
 
     expect(task.enabled).toBe(false)
   })
 
   async function runTask(args = baseArgs) {
-    return createAppTaskInstallDevSkill(args).task((value) => value)
+    return createAppTaskInstallSkills(args).task((value) => value)
   }
 
   function writePackageJson(init?: unknown) {

--- a/test/init-script-package-manager.test.ts
+++ b/test/init-script-package-manager.test.ts
@@ -1,3 +1,4 @@
+import { log } from '@clack/prompts'
 import { fs, vol } from 'memfs'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { GetArgsResult } from '../src/utils/get-args-result'
@@ -80,15 +81,36 @@ describe('initScriptPackageManager', () => {
     expect(getPackageManagerVersion).not.toHaveBeenCalled()
   })
 
-  it('should reject a template package manager that is not installed', () => {
+  it('should treat an omitted selection flag as explicit for programmatic callers', () => {
+    writePackageJson('bun')
+    const args: GetArgsResult = { ...baseArgs }
+    delete args.packageManagerExplicit
+
+    expect(() => initScriptPackageManager(args)).toThrow('Template requires bun, but npm was explicitly selected')
+    expect(args.packageManager).toBe('npm')
+    expect(getPackageManagerVersion).not.toHaveBeenCalled()
+  })
+
+  it('should reject a template package manager that is not available', () => {
     writePackageJson('bun')
     vi.mocked(getPackageManagerVersion).mockImplementation(() => {
       throw new Error('command not found')
     })
     const args = { ...baseArgs }
 
-    expect(() => initScriptPackageManager(args)).toThrow('Template requires bun, but bun is not installed')
+    expect(() => initScriptPackageManager(args)).toThrow('Template requires bun, but bun is not available')
     expect(args.packageManager).toBe('npm')
+  })
+
+  it('should log the package manager error in verbose mode', () => {
+    writePackageJson('bun')
+    vi.mocked(getPackageManagerVersion).mockImplementation(() => {
+      throw new Error('spawnSync /bin/sh ENOENT')
+    })
+    const args = { ...baseArgs, verbose: true }
+
+    expect(() => initScriptPackageManager(args)).toThrow('Template requires bun, but bun is not available')
+    expect(log.error).toHaveBeenCalledWith('Error checking bun availability: Error: spawnSync /bin/sh ENOENT')
   })
 
   function writePackageJson(packageManager?: string) {

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -54,7 +54,7 @@ describe('main', () => {
   })
 
   it.each([
-    'Template requires bun, but bun is not installed',
+    'Template requires bun, but bun is not available',
     'Template requires bun, but npm was explicitly selected',
   ])('should exit with a non-zero code when %s', async (message) => {
     vi.mocked(createApp).mockRejectedValue(new Error(message))


### PR DESCRIPTION
Preserve verbose package-manager errors while reporting unavailable executables accurately.

Rename the skill installation task to reflect support for multiple configured skills. Follow-up from #258