### PR TITLE
feat(cli): support template option flags

### DIFF
--- a/.changeset/template-option-flags.md
+++ b/.changeset/template-option-flags.md
@@ -1,5 +1,5 @@
 ---
-'create-solana-dapp': patch
+'create-solana-dapp': minor
 ---
 
 Support template-defined boolean CLI flags with defaults, mutually exclusive groups, file replacements, and post-create instructions.

--- a/.changeset/template-option-flags.md
+++ b/.changeset/template-option-flags.md
@@ -1,5 +1,5 @@
 ---
-'create-solana-dapp': minor
+'create-solana-dapp': patch
 ---
 
 Support template-defined boolean CLI flags with defaults, mutually exclusive groups, file replacements, and post-create instructions.

--- a/.changeset/template-option-flags.md
+++ b/.changeset/template-option-flags.md
@@ -1,0 +1,5 @@
+---
+'create-solana-dapp': minor
+---
+
+Support template-defined boolean CLI flags with defaults, mutually exclusive groups, file replacements, and post-create instructions.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,34 @@ in the project.
     // Optional. If omitted, the default Solana skill is installed.
     // Set to [] to skip skill installation, or provide one or more skill repo URLs to replace the default.
     "skills": ["https://github.com/org/skill-repo"],
+    // Optional boolean CLI flags declared by this template.
+    "options": {
+      // `--ollama` is selected when no option in the "engine" group is passed.
+      "ollama": {
+        "default": true,
+        "description": "Configure the template for Ollama",
+        "group": "engine",
+        "instructions": ["Start Ollama"],
+        "rename": {
+          "__MODEL__": {
+            "to": "qwen3:0.6b",
+            "paths": ["request.json"],
+          },
+        },
+      },
+      // Passing `--llamacpp` replaces the default from the same group.
+      "llamacpp": {
+        "description": "Configure the template for llama.cpp",
+        "group": "engine",
+        "instructions": ["Start llama-server"],
+        "rename": {
+          "__MODEL__": {
+            "to": "local-model",
+            "paths": ["request.json"],
+          },
+        },
+      },
+    },
     // Check versions and give a warning if it's not installed or the version is lower
     "versions": {
       "adb": "33.0.0",
@@ -87,6 +115,17 @@ in the project.
   },
 }
 ```
+
+Pass template-defined options as boolean long flags when creating the project:
+
+```shell
+pnpm create solana-dapp@latest my-inference-app \
+  --template pay-gate-inference \
+  --ollama
+```
+
+When no flag is passed for an option group, the group's default option is selected. Passing another option from that
+group, such as `--llamacpp`, replaces the default.
 
 ## Contributing
 

--- a/src/utils/create-app-task-run-init-script.ts
+++ b/src/utils/create-app-task-run-init-script.ts
@@ -3,6 +3,7 @@ import { GetArgsResult } from './get-args-result'
 import { getPackageJson } from './get-package-json'
 import { initScriptDelete } from './init-script-delete'
 import { initScriptInstructions } from './init-script-instructions'
+import { initScriptOptions } from './init-script-options'
 import { initScriptRename } from './init-script-rename'
 import { initScriptKey } from './init-script-schema'
 import { initScriptVersion } from './init-script-version'
@@ -24,9 +25,14 @@ export function createAppTaskRunInitScript(args: GetArgsResult): Task {
 
         await initScriptVersion(init.versions, args.verbose)
 
+        const optionInstructions = await initScriptOptions(args, init.options)
+
         await initScriptRename(args, init.rename, args.verbose)
 
-        const instructions: string[] = initScriptInstructions(init.instructions, args.verbose)
+        const instructions: string[] = initScriptInstructions(
+          [...optionInstructions, ...(init.instructions ?? [])],
+          args.verbose,
+        )
           ?.filter(Boolean)
           .map((msg) => msg.replace('{pm}', args.packageManager))
 

--- a/src/utils/extract-template-option-flags.ts
+++ b/src/utils/extract-template-option-flags.ts
@@ -3,8 +3,8 @@ import { Command } from 'commander'
 const templateOptionPattern = /^--([a-z][a-z0-9-]*)$/
 
 export interface ExtractTemplateOptionFlagsResult {
-  argv: string[]
-  templateOptions: string[]
+  readonly argv: string[]
+  readonly templateOptions: string[]
 }
 
 /**
@@ -14,38 +14,61 @@ export interface ExtractTemplateOptionFlagsResult {
  * its package metadata is available.
  */
 export function extractTemplateOptionFlags(command: Command, argv: string[]): ExtractTemplateOptionFlagsResult {
-  const unknown = command.parseOptions(argv.slice(2)).unknown
-  if (unknown.length === 0) {
-    return { argv, templateOptions: [] }
-  }
+  const knownArgv = argv.slice(0, 2)
+  const templateOptions = new Set<string>()
+  let preserveNextArgument = false
+  let positionalOnly = false
 
-  const templateOptions = unknown.map((arg) => {
+  for (const arg of argv.slice(2)) {
+    if (positionalOnly || preserveNextArgument) {
+      knownArgv.push(arg)
+      preserveNextArgument = false
+      continue
+    }
+
+    if (arg === '--') {
+      positionalOnly = true
+      knownArgv.push(arg)
+      continue
+    }
+
+    const knownOption = findKnownOption(command, arg)
+    if (knownOption) {
+      knownArgv.push(arg)
+      preserveNextArgument = knownOption.required && !hasInlineValue(knownOption.long, knownOption.short, arg)
+      continue
+    }
+
+    if (!arg.startsWith('-')) {
+      knownArgv.push(arg)
+      continue
+    }
+
     const match = templateOptionPattern.exec(arg)
     if (!match) {
       throw new Error(`Template options must be boolean long flags such as --ollama; received "${arg}".`)
     }
-    return match[1]
-  })
-
-  const remainingUnknown = new Map<string, number>()
-  for (const arg of unknown) {
-    remainingUnknown.set(arg, (remainingUnknown.get(arg) ?? 0) + 1)
+    templateOptions.add(match[1])
   }
-
-  const knownArgv = argv.filter((arg, index) => {
-    if (index < 2) {
-      return true
-    }
-    const count = remainingUnknown.get(arg) ?? 0
-    if (count === 0) {
-      return true
-    }
-    remainingUnknown.set(arg, count - 1)
-    return false
-  })
 
   return {
     argv: knownArgv,
-    templateOptions: [...new Set(templateOptions)],
+    templateOptions: [...templateOptions],
   }
+}
+
+function findKnownOption(command: Command, arg: string) {
+  const longFlag = arg.startsWith('--') ? arg.split('=', 1)[0] : undefined
+  const shortFlag = arg.startsWith('-') && !arg.startsWith('--') ? arg.slice(0, 2) : undefined
+  return command.options.find(
+    (option) =>
+      (longFlag !== undefined && option.long === longFlag) || (shortFlag !== undefined && option.short === shortFlag),
+  )
+}
+
+function hasInlineValue(longFlag: string | undefined, shortFlag: string | undefined, arg: string): boolean {
+  if (longFlag !== undefined && arg.startsWith('--')) {
+    return arg.startsWith(`${longFlag}=`)
+  }
+  return shortFlag !== undefined && arg.startsWith(shortFlag) && arg !== shortFlag
 }

--- a/src/utils/extract-template-option-flags.ts
+++ b/src/utils/extract-template-option-flags.ts
@@ -1,0 +1,51 @@
+import { Command } from 'commander'
+
+const templateOptionPattern = /^--([a-z][a-z0-9-]*)$/
+
+export interface ExtractTemplateOptionFlagsResult {
+  argv: string[]
+  templateOptions: string[]
+}
+
+/**
+ * Separates template-defined boolean flags from the arguments Commander knows.
+ *
+ * Template flags are validated after the selected template has been cloned and
+ * its package metadata is available.
+ */
+export function extractTemplateOptionFlags(command: Command, argv: string[]): ExtractTemplateOptionFlagsResult {
+  const unknown = command.parseOptions(argv.slice(2)).unknown
+  if (unknown.length === 0) {
+    return { argv, templateOptions: [] }
+  }
+
+  const templateOptions = unknown.map((arg) => {
+    const match = templateOptionPattern.exec(arg)
+    if (!match) {
+      throw new Error(`Template options must be boolean long flags such as --ollama; received "${arg}".`)
+    }
+    return match[1]
+  })
+
+  const remainingUnknown = new Map<string, number>()
+  for (const arg of unknown) {
+    remainingUnknown.set(arg, (remainingUnknown.get(arg) ?? 0) + 1)
+  }
+
+  const knownArgv = argv.filter((arg, index) => {
+    if (index < 2) {
+      return true
+    }
+    const count = remainingUnknown.get(arg) ?? 0
+    if (count === 0) {
+      return true
+    }
+    remainingUnknown.set(arg, count - 1)
+    return false
+  })
+
+  return {
+    argv: knownArgv,
+    templateOptions: [...new Set(templateOptions)],
+  }
+}

--- a/src/utils/get-args-result.ts
+++ b/src/utils/get-args-result.ts
@@ -14,5 +14,7 @@ export interface GetArgsResult {
   skipInstall: boolean
   targetDirectory: string
   template: Template
+  /** Boolean template-defined flags selected on the command line. */
+  templateOptions?: string[]
   verbose: boolean
 }

--- a/src/utils/get-args.ts
+++ b/src/utils/get-args.ts
@@ -1,6 +1,7 @@
 import { intro, log, outro } from '@clack/prompts'
 import { Command } from 'commander'
 import * as process from 'node:process'
+import { extractTemplateOptionFlags } from './extract-template-option-flags'
 import { fetchTemplateData } from './fetch-template-data'
 import { findTemplate } from './find-template'
 import { AppInfo } from './get-app-info'
@@ -49,7 +50,9 @@ Examples:
   $ ${app.name} my-app --pnpm # or --yarn
       `,
     )
-    .parse(argv)
+
+  const { argv: knownArgv, templateOptions } = extractTemplateOptionFlags(input, argv)
+  input.parse(knownArgv)
 
   // Get the optional name argument (positional)
   const name = input.args[0]
@@ -131,6 +134,7 @@ Examples:
     skipInstall: result.skipInstall ?? false,
     targetDirectory: `${cwd}/${name}`,
     template,
+    templateOptions,
     verbose,
   }
 

--- a/src/utils/init-script-options.ts
+++ b/src/utils/init-script-options.ts
@@ -1,0 +1,78 @@
+import { GetArgsResult } from './get-args-result'
+import { initScriptRenameEntries } from './init-script-rename'
+import { InitScriptOptions } from './init-script-schema'
+
+interface SelectedTemplateOption {
+  name: string
+  value: InitScriptOptions[string]
+}
+
+/**
+ * Resolves requested flags and group defaults from template option metadata.
+ */
+export function resolveInitScriptOptions(
+  options: InitScriptOptions | undefined,
+  requested: string[],
+): SelectedTemplateOption[] {
+  const definitions = options ?? {}
+  const available = Object.keys(definitions)
+  const unknown = requested.filter((name) => !definitions[name])
+  if (unknown.length > 0) {
+    const availableMessage =
+      available.length > 0 ? ` Available options: ${available.map((name) => `--${name}`).join(', ')}.` : ''
+    throw new Error(`Template does not support ${unknown.map((name) => `--${name}`).join(', ')}.${availableMessage}`)
+  }
+
+  const selected = new Set(requested)
+  const requestedGroups = new Set(
+    requested.flatMap((name) => {
+      const group = definitions[name].group
+      return group ? [group] : []
+    }),
+  )
+
+  for (const [name, option] of Object.entries(definitions)) {
+    if (!option.default) {
+      continue
+    }
+    if (!option.group || !requestedGroups.has(option.group)) {
+      selected.add(name)
+    }
+  }
+
+  const selectedOptions = [...selected].map((name) => ({ name, value: definitions[name] }))
+  const groups = new Map<string, string[]>()
+  for (const option of selectedOptions) {
+    if (!option.value.group) {
+      continue
+    }
+    const names = groups.get(option.value.group) ?? []
+    names.push(option.name)
+    groups.set(option.value.group, names)
+  }
+
+  for (const [group, names] of groups) {
+    if (names.length > 1) {
+      throw new Error(
+        `Template options ${names.map((name) => `--${name}`).join(' and ')} are mutually exclusive (group "${group}").`,
+      )
+    }
+  }
+
+  return selectedOptions
+}
+
+/**
+ * Applies the selected template option transformations and returns their
+ * post-create instructions.
+ */
+export async function initScriptOptions(
+  args: GetArgsResult,
+  options: InitScriptOptions | undefined,
+): Promise<string[]> {
+  const selected = resolveInitScriptOptions(options, args.templateOptions ?? [])
+  for (const option of selected) {
+    await initScriptRenameEntries(args, option.value.rename)
+  }
+  return selected.flatMap((option) => option.value.instructions ?? [])
+}

--- a/src/utils/init-script-rename.ts
+++ b/src/utils/init-script-rename.ts
@@ -73,33 +73,39 @@ function packageNameReplacementValues(from: string, to: string): { fromNames: st
 }
 
 function initScriptRenameReplacementValues(from: string, to: string): { fromNames: string[]; toNames: string[] } {
+  const replacements = new Map<string, string>()
   const fromNames = namesValues(from)
-  let toNames = namesValues(to)
+  const toNames = namesValues(to)
 
-  if (/\s/.test(from)) {
-    const displayName = toDisplayName(to)
-    const displayIndex = fromNames.indexOf(from)
-    if (displayIndex !== -1) {
-      toNames = toNames.map((toName, index) => (index === displayIndex ? displayName : toName))
+  for (const [index, fromName] of fromNames.entries()) {
+    let toName = toNames[index]
+    if (fromName === from) {
+      toName = /\s/.test(from) ? toDisplayName(to) : to
+    }
+    if (!replacements.has(fromName)) {
+      replacements.set(fromName, toName)
     }
   }
 
-  return { fromNames, toNames }
+  return {
+    fromNames: [...replacements.keys()],
+    toNames: [...replacements.values()],
+  }
 }
 
-export async function initScriptRename(args: GetArgsResult, rename?: InitScriptRename, verbose = false) {
-  const tag = `initScriptRename`
+async function renameProject(args: GetArgsResult, verbose: boolean) {
   const { contents } = getPackageJson(args.targetDirectory)
-  // Rename template from package.json to project name throughout the whole project
   if (contents.name) {
     if (args.verbose) {
-      log.warn(`${tag}: renaming template name '${contents.name}' to project name '${args.name}'`)
+      log.warn(`initScriptRename: renaming template name '${contents.name}' to project name '${args.name}'`)
     }
     const { fromNames, toNames } = packageNameReplacementValues(contents.name, args.name)
     await searchAndReplace(args.targetDirectory, fromNames, toNames, args.dryRun, verbose)
   }
+}
 
-  // Return early if there are no renames defined in the init script
+export async function initScriptRenameEntries(args: GetArgsResult, rename?: InitScriptRename) {
+  const tag = `initScriptRename`
   if (!rename) {
     if (args.verbose) {
       log.warn(`${tag}: no renames found`)
@@ -107,20 +113,8 @@ export async function initScriptRename(args: GetArgsResult, rename?: InitScriptR
     return
   }
 
-  // Loop through each word in the rename object
   for (const from of Object.keys(rename)) {
-    // Skip if the 'from' value matches the package.json name (already replaced above)
-    if (from === contents.name) {
-      if (args.verbose) {
-        log.warn(`${tag}: skipping rename for '${from}' as it matches package.json name (already replaced)`)
-      }
-      continue
-    }
-
-    // Get the 'to' property from the rename object
     const to = rename[from].to.replace('{{name}}', args.name)
-
-    // Get the name matrix for the 'from' and the 'to' value
     const { fromNames, toNames } = initScriptRenameReplacementValues(from, to)
 
     for (const path of rename[from].paths) {
@@ -139,4 +133,20 @@ export async function initScriptRename(args: GetArgsResult, rename?: InitScriptR
   if (args.verbose) {
     log.warn(`${tag}: done`)
   }
+}
+
+export async function initScriptRename(args: GetArgsResult, rename?: InitScriptRename, verbose = false) {
+  const { contents } = getPackageJson(args.targetDirectory)
+  await renameProject(args, verbose)
+
+  if (contents.name && rename?.[contents.name]) {
+    const { [contents.name]: _packageName, ...remainingRename } = rename
+    if (args.verbose) {
+      log.warn(`initScriptRename: skipping rename for '${contents.name}' as it matches package.json name`)
+    }
+    await initScriptRenameEntries(args, remainingRename)
+    return
+  }
+
+  await initScriptRenameEntries(args, rename)
 }

--- a/src/utils/init-script-schema.ts
+++ b/src/utils/init-script-schema.ts
@@ -24,8 +24,19 @@ export const InitScriptSchemaRename = z.record(
   }),
 )
 
+export const InitScriptSchemaOption = z.object({
+  default: z.boolean().optional(),
+  description: z.string().optional(),
+  group: z.string().min(1).optional(),
+  instructions: InitScriptSchemaInstructions.optional(),
+  rename: InitScriptSchemaRename.optional(),
+})
+
+export const InitScriptSchemaOptions = z.record(z.string().regex(/^[a-z][a-z0-9-]*$/), InitScriptSchemaOption)
+
 export const InitScriptSchema = z.object({
   instructions: InitScriptSchemaInstructions.optional(),
+  options: InitScriptSchemaOptions.optional(),
   packageManager: InitScriptSchemaPackageManager.optional(),
   rename: InitScriptSchemaRename.optional(),
   skills: InitScriptSchemaSkills.optional(),
@@ -33,6 +44,8 @@ export const InitScriptSchema = z.object({
 })
 
 export type InitScriptInstructions = z.infer<typeof InitScriptSchemaInstructions>
+export type InitScriptOption = z.infer<typeof InitScriptSchemaOption>
+export type InitScriptOptions = z.infer<typeof InitScriptSchemaOptions>
 export type InitScriptPackageManager = z.infer<typeof InitScriptSchemaPackageManager>
 export type InitScriptRename = z.infer<typeof InitScriptSchemaRename>
 export type InitScriptSkills = z.infer<typeof InitScriptSchemaSkills>

--- a/src/utils/search-and-replace.ts
+++ b/src/utils/search-and-replace.ts
@@ -1,4 +1,4 @@
-import { readdir, readFile, rename, writeFile } from 'node:fs/promises'
+import { lstat, readdir, readFile, rename, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 
 const EXCLUDED_DIRECTORIES = new Set(['dist', 'coverage', 'node_modules', '.git', 'tmp'])
@@ -124,6 +124,15 @@ export async function searchAndReplace(
   }
 
   try {
+    const rootStats = await lstat(rootFolder)
+    if (rootStats.isFile()) {
+      await processFile(rootFolder)
+      if (isVerbose) {
+        console.log(isDryRun ? 'Dry run completed' : 'Search and replace completed')
+      }
+      return
+    }
+
     await processDirectory(rootFolder)
     await renamePaths(rootFolder)
     if (isVerbose) {

--- a/test/extract-template-option-flags.test.ts
+++ b/test/extract-template-option-flags.test.ts
@@ -1,0 +1,36 @@
+import { Command } from 'commander'
+import { describe, expect, it } from 'vitest'
+import { extractTemplateOptionFlags } from '../src/utils/extract-template-option-flags'
+
+function command() {
+  return new Command().argument('[name]').option('-t, --template <template-name>')
+}
+
+describe('extractTemplateOptionFlags', () => {
+  it('extracts boolean long flags while preserving known arguments', () => {
+    const argv = ['node', 'create-solana-dapp', 'my-app', '--template', 'pay-gate-inference', '--ollama']
+
+    expect(extractTemplateOptionFlags(command(), argv)).toEqual({
+      argv: ['node', 'create-solana-dapp', 'my-app', '--template', 'pay-gate-inference'],
+      templateOptions: ['ollama'],
+    })
+  })
+
+  it('deduplicates repeated template flags', () => {
+    const argv = ['node', 'create-solana-dapp', 'my-app', '--ollama', '--ollama']
+
+    expect(extractTemplateOptionFlags(command(), argv)).toEqual({
+      argv: ['node', 'create-solana-dapp', 'my-app'],
+      templateOptions: ['ollama'],
+    })
+  })
+
+  it('rejects short flags and values for template options', () => {
+    expect(() => extractTemplateOptionFlags(command(), ['node', 'create-solana-dapp', 'my-app', '-o'])).toThrow(
+      'Template options must be boolean long flags',
+    )
+    expect(() =>
+      extractTemplateOptionFlags(command(), ['node', 'create-solana-dapp', 'my-app', '--engine', 'ollama']),
+    ).toThrow('Template options must be boolean long flags')
+  })
+})

--- a/test/extract-template-option-flags.test.ts
+++ b/test/extract-template-option-flags.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { extractTemplateOptionFlags } from '../src/utils/extract-template-option-flags'
 
 function command() {
-  return new Command().argument('[name]').option('-t, --template <template-name>')
+  return new Command().argument('[name]').option('-t, --template <template-name>').option('--skip-install')
 }
 
 describe('extractTemplateOptionFlags', () => {
@@ -25,12 +25,38 @@ describe('extractTemplateOptionFlags', () => {
     })
   })
 
+  it('preserves positional and registered arguments after a template flag', () => {
+    const argv = [
+      'node',
+      'create-solana-dapp',
+      '--ollama',
+      'my-app',
+      '--skip-install',
+      '--template',
+      'pay-gate-inference',
+    ]
+
+    expect(extractTemplateOptionFlags(command(), argv)).toEqual({
+      argv: ['node', 'create-solana-dapp', 'my-app', '--skip-install', '--template', 'pay-gate-inference'],
+      templateOptions: ['ollama'],
+    })
+  })
+
+  it('preserves a required option value that resembles a template flag', () => {
+    const argv = ['node', 'create-solana-dapp', 'my-app', '--template', '--ollama']
+
+    expect(extractTemplateOptionFlags(command(), argv)).toEqual({
+      argv,
+      templateOptions: [],
+    })
+  })
+
   it('rejects short flags and values for template options', () => {
     expect(() => extractTemplateOptionFlags(command(), ['node', 'create-solana-dapp', 'my-app', '-o'])).toThrow(
       'Template options must be boolean long flags',
     )
     expect(() =>
-      extractTemplateOptionFlags(command(), ['node', 'create-solana-dapp', 'my-app', '--engine', 'ollama']),
+      extractTemplateOptionFlags(command(), ['node', 'create-solana-dapp', 'my-app', '--engine=ollama']),
     ).toThrow('Template options must be boolean long flags')
   })
 })

--- a/test/get-args.test.ts
+++ b/test/get-args.test.ts
@@ -118,4 +118,15 @@ describe('getArgs', () => {
     expect(outro).not.toHaveBeenCalled()
     expect(runVersionCheck).not.toHaveBeenCalled()
   })
+
+  it('collects template-defined boolean flags without registering them globally', async () => {
+    const args = await getArgs(
+      ['node', 'create-solana-dapp', 'my-app', '--template', 'basic', '--llamacpp', '--skip-version-check'],
+      app,
+    )
+
+    expect(args.name).toBe('my-app')
+    expect(args.templateOptions).toEqual(['llamacpp'])
+    expect(args.template).toBe(template)
+  })
 })

--- a/test/get-args.test.ts
+++ b/test/get-args.test.ts
@@ -129,4 +129,27 @@ describe('getArgs', () => {
     expect(args.templateOptions).toEqual(['llamacpp'])
     expect(args.template).toBe(template)
   })
+
+  it('parses positional and registered arguments after a template-defined flag', async () => {
+    const args = await getArgs(
+      [
+        'node',
+        'create-solana-dapp',
+        '--llamacpp',
+        'my-app',
+        '--skip-install',
+        '--template',
+        'basic',
+        '--skip-version-check',
+      ],
+      app,
+    )
+
+    expect(args).toMatchObject({
+      name: 'my-app',
+      skipInstall: true,
+      template,
+      templateOptions: ['llamacpp'],
+    })
+  })
 })

--- a/test/init-script-options.test.ts
+++ b/test/init-script-options.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { GetArgsResult } from '../src/utils/get-args-result'
+import { initScriptOptions, resolveInitScriptOptions } from '../src/utils/init-script-options'
+import { initScriptRenameEntries } from '../src/utils/init-script-rename'
+import { InitScriptOptions } from '../src/utils/init-script-schema'
+
+vi.mock('../src/utils/init-script-rename', () => ({
+  initScriptRenameEntries: vi.fn(),
+}))
+
+const options: InitScriptOptions = {
+  llamacpp: {
+    group: 'engine',
+    instructions: ['Start llama.cpp'],
+    rename: {
+      __MODEL__: { paths: ['request.json'], to: 'local-model' },
+    },
+  },
+  ollama: {
+    default: true,
+    group: 'engine',
+    instructions: ['Start Ollama'],
+    rename: {
+      __MODEL__: { paths: ['request.json'], to: 'qwen3:0.6b' },
+    },
+  },
+}
+
+const args: GetArgsResult = {
+  app: { name: 'test-app', version: '1.0.0' },
+  dryRun: false,
+  name: 'test-project',
+  packageManager: 'npm',
+  skipGit: false,
+  skipInit: false,
+  skipInstall: false,
+  targetDirectory: '/template',
+  template: { description: 'description', name: 'basic', repository: '/template' },
+  verbose: false,
+}
+
+describe('resolveInitScriptOptions', () => {
+  it('selects the group default when no flag is requested', () => {
+    expect(resolveInitScriptOptions(options, []).map((option) => option.name)).toEqual(['ollama'])
+  })
+
+  it('replaces the group default with the requested option', () => {
+    expect(resolveInitScriptOptions(options, ['llamacpp']).map((option) => option.name)).toEqual(['llamacpp'])
+  })
+
+  it('rejects unknown and conflicting options', () => {
+    expect(() => resolveInitScriptOptions(options, ['unknown'])).toThrow(
+      'Template does not support --unknown. Available options: --llamacpp, --ollama.',
+    )
+    expect(() => resolveInitScriptOptions(options, ['ollama', 'llamacpp'])).toThrow(
+      'Template options --ollama and --llamacpp are mutually exclusive',
+    )
+  })
+})
+
+describe('initScriptOptions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('applies selected renames and returns selected instructions', async () => {
+    const instructions = await initScriptOptions({ ...args, templateOptions: ['llamacpp'] }, options)
+
+    expect(initScriptRenameEntries).toHaveBeenCalledWith(expect.any(Object), options.llamacpp.rename)
+    expect(instructions).toEqual(['Start llama.cpp'])
+  })
+})

--- a/test/init-script-rename.test.ts
+++ b/test/init-script-rename.test.ts
@@ -111,6 +111,32 @@ describe('initScriptRename', () => {
     )
   })
 
+  it('should preserve punctuation in exact replacement values', async () => {
+    const args = { ...baseArgs }
+    const rename = {
+      'inference-model': {
+        paths: ['request.json'],
+        to: 'qwen3:0.6b',
+      },
+    }
+    vi.mocked(namesValues).mockImplementation((name) =>
+      name === 'inference-model'
+        ? ['InferenceModel', 'INFERENCE_MODEL', 'inference-model', 'inference-model', 'inferenceModel']
+        : ['Qwen306b', 'QWEN306B', 'qwen306b', 'qwen3:0.6b', 'qwen306b'],
+    )
+    vi.mocked(ensureTargetPath).mockResolvedValue(true)
+
+    await initScriptRename(args, rename)
+
+    expect(searchAndReplace).toHaveBeenLastCalledWith(
+      '/template/request.json',
+      ['InferenceModel', 'INFERENCE_MODEL', 'inference-model', 'inferenceModel'],
+      ['Qwen306b', 'QWEN306B', 'qwen3:0.6b', 'qwen306b'],
+      false,
+      false,
+    )
+  })
+
   it('should use dry run mode when replacing the project name from package.json', async () => {
     const args = { ...baseArgs, dryRun: true }
 

--- a/test/search-and-replace.test.ts
+++ b/test/search-and-replace.test.ts
@@ -55,6 +55,14 @@ describe('searchAndReplace', () => {
     await expect(access(join(tempDir, 'oldname.txt'))).rejects.toThrow()
   })
 
+  it('should replace content when the target is an individual file', async () => {
+    const filePath = join(tempDir, 'file1.txt')
+
+    await searchAndReplace(filePath, ['Hello'], ['Hi'])
+
+    expect(await readFile(filePath, 'utf8')).toBe('Hi world')
+  })
+
   it('should treat search values as literal strings', async () => {
     await writeFile(join(tempDir, 'foo.bar.txt'), 'foo.bar fooXbar')
     await writeFile(join(tempDir, 'fooXbar.txt'), 'fooXbar')


### PR DESCRIPTION
## Summary
- accept template-defined boolean CLI flags without registering them globally
- support default options, mutually exclusive groups, option-specific instructions, and scoped replacements
- preserve literal replacement values such as qwen3:0.6b and support individual-file targets
- document the template option contract and add a minor changeset

## Test Plan
- pnpm test
- pnpm build
- generate the pay-gate-inference template with --ollama and confirm request.json uses qwen3:0.6b
- generate the pay-gate-inference template with --llamacpp and confirm request.json uses local-model

Enables the engine flags used by solana-foundation/templates#446.