### PR TITLE
feat: export template catalog and init script schemas

### DIFF
--- a/.changeset/export-template-schemas.md
+++ b/.changeset/export-template-schemas.md
@@ -1,0 +1,5 @@
+---
+'create-solana-dapp': minor
+---
+
+Export the template catalog and init script Zod schemas from the package root so external tooling can validate and generate templates against a single source of truth.

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,10 +16,36 @@ export { getAppInfo } from './utils/get-app-info'
 export type { AppInfo } from './utils/get-app-info'
 export { getArgs } from './utils/get-args'
 export type { GetArgsResult } from './utils/get-args-result'
+export {
+  initScriptKey,
+  InitScriptSchema,
+  InitScriptSchemaInstructions,
+  InitScriptSchemaOption,
+  InitScriptSchemaOptions,
+  InitScriptSchemaPackageManager,
+  InitScriptSchemaRename,
+  InitScriptSchemaSkills,
+  InitScriptSchemaVersions,
+} from './utils/init-script-schema'
+export type {
+  InitScriptInstructions,
+  InitScriptOption,
+  InitScriptOptions,
+  InitScriptPackageManager,
+  InitScriptRename,
+  InitScriptSkills,
+  InitScriptVersions,
+} from './utils/init-script-schema'
 export { listTemplateIds } from './utils/list-template-ids'
 export { listTemplates } from './utils/list-templates'
 export { listVersions } from './utils/list-versions'
 export type { Template } from './utils/template'
+export {
+  parseTemplateJson,
+  templateJsonGroupSchema,
+  templateJsonSchema,
+  templateJsonTemplateSchema,
+} from './utils/template-schema'
 export type {
   MenuConfig,
   MenuConfigItem,

--- a/test/root-exports-schemas.test.ts
+++ b/test/root-exports-schemas.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, expectTypeOf, it } from 'vitest'
+import {
+  initScriptKey,
+  InitScriptSchema,
+  InitScriptSchemaInstructions,
+  InitScriptSchemaOption,
+  InitScriptSchemaOptions,
+  InitScriptSchemaPackageManager,
+  InitScriptSchemaRename,
+  InitScriptSchemaSkills,
+  InitScriptSchemaVersions,
+  parseTemplateJson,
+  templateJsonGroupSchema,
+  templateJsonSchema,
+  templateJsonTemplateSchema,
+} from '../src/index'
+import type {
+  InitScriptInstructions,
+  InitScriptOption,
+  InitScriptOptions,
+  InitScriptPackageManager,
+  InitScriptRename,
+  InitScriptSkills,
+  InitScriptVersions,
+} from '../src/index'
+import * as initScriptSchemaModule from '../src/utils/init-script-schema'
+import * as templateSchemaModule from '../src/utils/template-schema'
+
+const templateGroup = {
+  description: 'Templates for mobile apps',
+  name: 'mobile',
+  path: 'templates/mobile',
+  templates: [
+    {
+      description: 'A React Native app',
+      displayName: 'React Native',
+      id: 'mobile-react-native',
+      keywords: ['mobile', 'react-native'],
+      name: 'react-native',
+      path: 'templates/mobile/react-native',
+    },
+  ],
+}
+
+describe('package root schema exports', () => {
+  it('exports the template catalog schemas', () => {
+    const exportedSchemas = {
+      parseTemplateJson,
+      templateJsonGroupSchema,
+      templateJsonSchema,
+      templateJsonTemplateSchema,
+    }
+
+    expect(Object.keys(exportedSchemas)).toEqual([
+      'parseTemplateJson',
+      'templateJsonGroupSchema',
+      'templateJsonSchema',
+      'templateJsonTemplateSchema',
+    ])
+
+    // The root export must be the same instance the CLI uses, not a copy
+    expect(templateJsonSchema).toBe(templateSchemaModule.templateJsonSchema)
+    expect(templateJsonGroupSchema).toBe(templateSchemaModule.templateJsonGroupSchema)
+    expect(templateJsonTemplateSchema).toBe(templateSchemaModule.templateJsonTemplateSchema)
+    expect(parseTemplateJson).toBe(templateSchemaModule.parseTemplateJson)
+  })
+
+  it('exports the init script schemas', () => {
+    const exportedSchemas = {
+      InitScriptSchema,
+      InitScriptSchemaInstructions,
+      InitScriptSchemaOption,
+      InitScriptSchemaOptions,
+      InitScriptSchemaPackageManager,
+      InitScriptSchemaRename,
+      InitScriptSchemaSkills,
+      InitScriptSchemaVersions,
+    }
+
+    expect(Object.keys(exportedSchemas)).toEqual([
+      'InitScriptSchema',
+      'InitScriptSchemaInstructions',
+      'InitScriptSchemaOption',
+      'InitScriptSchemaOptions',
+      'InitScriptSchemaPackageManager',
+      'InitScriptSchemaRename',
+      'InitScriptSchemaSkills',
+      'InitScriptSchemaVersions',
+    ])
+
+    // The root export must be the same instance the CLI uses, not a copy
+    expect(InitScriptSchema).toBe(initScriptSchemaModule.InitScriptSchema)
+    expect(InitScriptSchemaInstructions).toBe(initScriptSchemaModule.InitScriptSchemaInstructions)
+    expect(InitScriptSchemaOption).toBe(initScriptSchemaModule.InitScriptSchemaOption)
+    expect(InitScriptSchemaOptions).toBe(initScriptSchemaModule.InitScriptSchemaOptions)
+    expect(InitScriptSchemaPackageManager).toBe(initScriptSchemaModule.InitScriptSchemaPackageManager)
+    expect(InitScriptSchemaRename).toBe(initScriptSchemaModule.InitScriptSchemaRename)
+    expect(InitScriptSchemaSkills).toBe(initScriptSchemaModule.InitScriptSchemaSkills)
+    expect(InitScriptSchemaVersions).toBe(initScriptSchemaModule.InitScriptSchemaVersions)
+    expect(initScriptKey).toBe(initScriptSchemaModule.initScriptKey)
+  })
+
+  it('validates a template catalog through the root exports', () => {
+    expect(templateJsonSchema.safeParse([templateGroup]).success).toBe(true)
+    expect(templateJsonGroupSchema.safeParse(templateGroup).success).toBe(true)
+    expect(templateJsonTemplateSchema.safeParse(templateGroup.templates[0]).success).toBe(true)
+
+    const invalid = templateJsonSchema.safeParse([{ ...templateGroup, name: 42 }])
+    expect(invalid.success).toBe(false)
+
+    expect(parseTemplateJson(JSON.stringify([templateGroup])).success).toBe(true)
+    expect(parseTemplateJson('not json').success).toBe(false)
+  })
+
+  it('validates an init script through the root exports', () => {
+    const initScript = {
+      instructions: ['pnpm install'],
+      options: {
+        'mobile-wallet': {
+          default: true,
+          description: 'Include mobile wallet adapter',
+          group: 'mobile',
+          instructions: ['pnpm run android'],
+          rename: { 'wallet-name': { paths: ['app'], to: 'my-wallet' } },
+        },
+      },
+      packageManager: 'pnpm',
+      rename: { 'anchor-project': { paths: ['anchor'], to: 'my-project' } },
+      skills: ['solana-dev'],
+      versions: { anchor: '0.31.1', solana: '2.1.0' },
+    }
+
+    expect(InitScriptSchema.safeParse(initScript).success).toBe(true)
+    expect(InitScriptSchema.safeParse({}).success).toBe(true)
+    expect(InitScriptSchema.safeParse({ packageManager: 'not-a-package-manager' }).success).toBe(false)
+
+    expect(InitScriptSchemaInstructions.safeParse(initScript.instructions).success).toBe(true)
+    expect(InitScriptSchemaOption.safeParse(initScript.options['mobile-wallet']).success).toBe(true)
+    expect(InitScriptSchemaOptions.safeParse(initScript.options).success).toBe(true)
+    // Option keys are constrained to lowercase kebab-case flag names
+    expect(InitScriptSchemaOptions.safeParse({ 'Mobile Wallet': {} }).success).toBe(false)
+    expect(InitScriptSchemaPackageManager.safeParse('npm').success).toBe(true)
+    expect(InitScriptSchemaRename.safeParse(initScript.rename).success).toBe(true)
+    expect(InitScriptSchemaSkills.safeParse(initScript.skills).success).toBe(true)
+    expect(InitScriptSchemaVersions.safeParse(initScript.versions).success).toBe(true)
+
+    expect(initScriptKey).toBe('create-solana-dapp')
+  })
+
+  it('exports the init script types inferred from the schemas', () => {
+    expectTypeOf<InitScriptInstructions>().toEqualTypeOf<string[]>()
+    expectTypeOf<InitScriptSkills>().toEqualTypeOf<string[]>()
+    expectTypeOf<InitScriptPackageManager>().toEqualTypeOf<'bun' | 'npm' | 'pnpm' | 'yarn'>()
+    expectTypeOf<InitScriptRename>().toEqualTypeOf<Record<string, { paths: string[]; to: string }>>()
+    expectTypeOf<InitScriptOption>().toEqualTypeOf<{
+      default?: boolean
+      description?: string
+      group?: string
+      instructions?: string[]
+      rename?: InitScriptRename
+    }>()
+    expectTypeOf<InitScriptOptions>().toEqualTypeOf<Record<string, InitScriptOption>>()
+    expectTypeOf<InitScriptVersions>().toEqualTypeOf<{ adb?: string; anchor?: string; solana?: string }>()
+  })
+})


### PR DESCRIPTION
Re-export the template catalog schemas (templateJsonSchema, templateJsonGroupSchema, templateJsonTemplateSchema, parseTemplateJson) and the init script schemas (InitScriptSchema and its instructions, package manager, rename, skills, and versions members) plus initScriptKey and the inferred init script types from the package root, so external tooling can validate and generate templates against the same definitions the CLI uses.

The schema modules are untouched, so the exported values are the same instances the CLI consumes rather than copies. Add root export tests covering instance identity against the internal modules and valid and invalid parse cases for both schema groups, and a minor changeset.
