### PR TITLE
feat: migrate exported schemas to zod v4

### DIFF
--- a/.changeset/zod-v4-schemas.md
+++ b/.changeset/zod-v4-schemas.md
@@ -1,0 +1,5 @@
+---
+'create-solana-dapp': minor
+---
+
+Migrate the init script and `package.json` schemas off the `zod/v3` compatibility import so every exported schema is a native Zod 4 schema, and declare `zod` as an optional peer dependency so consumers share a single Zod instance with the package.

--- a/package.json
+++ b/package.json
@@ -90,6 +90,14 @@
     "update-notifier": "7.3.1",
     "zod": "4.4.3"
   },
+  "peerDependencies": {
+    "zod": "^4"
+  },
+  "peerDependenciesMeta": {
+    "zod": {
+      "optional": true
+    }
+  },
   "contributors": [
     {
       "name": "Joe Caulfield",

--- a/src/utils/get-package-json.ts
+++ b/src/utils/get-package-json.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from 'node:fs'
-import { z } from 'zod/v3'
+import { z } from 'zod'
 import { getPackageJsonPath } from './get-package-json-path'
 import { initScriptKey, InitScriptSchema } from './init-script-schema'
 
@@ -23,13 +23,11 @@ export function getPackageJson(targetDirectory: string): { contents: PackageJson
   return { contents: parsed.data, path }
 }
 
-const PackageJsonSchema = z
-  .object({
-    [initScriptKey]: InitScriptSchema.optional(),
-    name: z.string().optional(),
-    packageManager: z.string().optional(),
-    scripts: z.record(z.string()).optional(),
-  })
-  .passthrough()
+const PackageJsonSchema = z.looseObject({
+  [initScriptKey]: InitScriptSchema.optional(),
+  name: z.string().optional(),
+  packageManager: z.string().optional(),
+  scripts: z.record(z.string(), z.string()).optional(),
+})
 
 export type PackageJson = z.infer<typeof PackageJsonSchema>

--- a/src/utils/init-script-schema.ts
+++ b/src/utils/init-script-schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod/v3'
+import { z } from 'zod'
 import { packageManagers } from './vendor/package-manager'
 
 // This is the key used in package.json to store the init script
@@ -17,6 +17,7 @@ export const InitScriptSchemaVersions = z.object({
 })
 
 export const InitScriptSchemaRename = z.record(
+  z.string(),
   z.object({
     // TODO: Rename 'paths' to 'in' (breaking change)
     paths: z.array(z.string()),

--- a/test/get-package-json.test.ts
+++ b/test/get-package-json.test.ts
@@ -36,13 +36,12 @@ describe('getPackageJson', () => {
 
     expect(() => getPackageJson(targetDirectory)).toThrow(`Invalid package.json: [
   {
+    "expected": "record",
     "code": "invalid_type",
-    "expected": "object",
-    "received": "string",
     "path": [
       "scripts"
     ],
-    "message": "Expected object, received string"
+    "message": "Invalid input: expected record, received string"
   }
 ]`)
   })


### PR DESCRIPTION
Replace the `zod/v3` compatibility imports in the init script and package.json schemas with native Zod 4 imports, so every schema exported from the package root is a real Zod 4 schema.

Update both `z.record()` calls to the Zod 4 two-argument form. This also corrects `scripts` in `PackageJsonSchema`, which was inferring `Record<string, unknown>` instead of `Record<string, string>`, and replaces the deprecated `.passthrough()` with `z.looseObject()`.

Declare `zod` as an optional peer dependency alongside the existing dependency so consumers importing the exported schemas resolve to a single Zod instance.

Zod 4 reworded type errors, so the `getPackageJson` schema failure assertion now expects `Invalid input: expected record, received string`.
