### PR TITLE
chore: ignore build directories at any depth in eslint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,11 +5,12 @@ import sort from 'eslint-plugin-sort'
 export default unjs(
   {
     ignores: [
-      // ignore paths
-      'coverage',
-      'dist',
-      'node_modules',
-      'tmp',
+      // ignore paths (the `**/` prefix is required to match at any depth, not just the repo root)
+      '**/.claude',
+      '**/coverage',
+      '**/dist',
+      '**/node_modules',
+      '**/tmp',
     ],
     markdown: {
       rules: {


### PR DESCRIPTION
The ignore patterns were bare names, and ESLint flat config resolves a pattern without a leading slash or globstar relative to the config base path. That limited them to the repository root, so nested coverage, dist, node_modules, and tmp directories were still linted.

Prefix each pattern with a globstar so it matches at any depth, and ignore .claude, which holds tooling state rather than source.
