### PR TITLE
feat: accept `in` for rename entries and deprecate `paths`

### DIFF
--- a/.changeset/rename-in-deprecate-paths.md
+++ b/.changeset/rename-in-deprecate-paths.md
@@ -1,0 +1,5 @@
+---
+'create-solana-dapp': minor
+---
+
+Accept `in` for rename entries in the init script and deprecate `paths`. Templates using `paths` keep working and now log a deprecation warning; support for `paths` is removed in the next major version. An entry must set exactly one of the two.

--- a/README.md
+++ b/README.md
@@ -69,10 +69,11 @@ in the project.
     "rename": {
       // Rename every instance of counter
       "counter": {
+        // In the following paths. Was called 'paths', which is deprecated and
+        // is removed in the next major version.
+        "in": ["anchor", "src"],
         // With the name of the project
         "to": "{{name}}",
-        // In the following paths
-        "paths": ["anchor", "src"],
       },
     },
     // Optional. If omitted, the default Solana skill is installed.
@@ -88,8 +89,8 @@ in the project.
         "instructions": ["Start Ollama"],
         "rename": {
           "__MODEL__": {
+            "in": ["request.json"],
             "to": "qwen3:0.6b",
-            "paths": ["request.json"],
           },
         },
       },
@@ -100,8 +101,8 @@ in the project.
         "instructions": ["Start llama-server"],
         "rename": {
           "__MODEL__": {
+            "in": ["request.json"],
             "to": "local-model",
-            "paths": ["request.json"],
           },
         },
       },

--- a/src/utils/init-script-rename.ts
+++ b/src/utils/init-script-rename.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path'
 import { ensureTargetPath } from './ensure-target-path'
 import { GetArgsResult } from './get-args-result'
 import { getPackageJson } from './get-package-json'
-import { InitScriptRename } from './init-script-schema'
+import { InitScriptRename, InitScriptRenameEntry } from './init-script-schema'
 import { searchAndReplace } from './search-and-replace'
 import { namesValues } from './vendor/names'
 
@@ -46,6 +46,11 @@ function toPascalName(name: string): string {
 
 function toSnakeName(name: string): string {
   return getNameSegments(name).join('_').toLowerCase()
+}
+
+function renameEntryPaths(entry: InitScriptRenameEntry): string[] {
+  // `paths` is the deprecated spelling of `in`; the schema guarantees exactly one of them is set
+  return entry.in ?? entry.paths ?? []
 }
 
 function packageNameReplacementValues(from: string, to: string): { fromNames: string[]; toNames: string[] } {
@@ -113,11 +118,18 @@ export async function initScriptRenameEntries(args: GetArgsResult, rename?: Init
     return
   }
 
+  const deprecated = Object.keys(rename).filter((from) => rename[from].paths)
+  if (deprecated.length > 0) {
+    log.warn(
+      `${tag}: 'paths' is deprecated and is removed in the next major version, use 'in' instead: ${deprecated.join(', ')}`,
+    )
+  }
+
   for (const from of Object.keys(rename)) {
     const to = rename[from].to.replace('{{name}}', args.name)
     const { fromNames, toNames } = initScriptRenameReplacementValues(from, to)
 
-    for (const path of rename[from].paths) {
+    for (const path of renameEntryPaths(rename[from])) {
       const targetPath = join(args.targetDirectory, path)
       if (!(await ensureTargetPath(targetPath))) {
         log.error(`${tag}: target does not exist ${targetPath}`)

--- a/src/utils/init-script-schema.ts
+++ b/src/utils/init-script-schema.ts
@@ -16,14 +16,35 @@ export const InitScriptSchemaVersions = z.object({
   solana: z.string().optional(),
 })
 
-export const InitScriptSchemaRename = z.record(
-  z.string(),
-  z.object({
-    // TODO: Rename 'paths' to 'in' (breaking change)
-    paths: z.array(z.string()),
+export const InitScriptSchemaRenameEntry = z
+  .object({
+    in: z.array(z.string()).optional(),
+    /** @deprecated Use `in` instead. Support for `paths` is removed in the next major version. */
+    paths: z.array(z.string()).optional(),
     to: z.string(),
-  }),
-)
+  })
+  .check((payload) => {
+    const { in: paths, paths: deprecatedPaths } = payload.value
+
+    if (paths && deprecatedPaths) {
+      payload.issues.push({
+        code: 'custom',
+        input: payload.value,
+        message: `Use either 'in' or 'paths', not both ('paths' is deprecated, use 'in')`,
+      })
+      return
+    }
+
+    if (!paths && !deprecatedPaths) {
+      payload.issues.push({
+        code: 'custom',
+        input: payload.value,
+        message: `Missing 'in': list the paths to search for this rename`,
+      })
+    }
+  })
+
+export const InitScriptSchemaRename = z.record(z.string(), InitScriptSchemaRenameEntry)
 
 export const InitScriptSchemaOption = z.object({
   default: z.boolean().optional(),
@@ -49,5 +70,6 @@ export type InitScriptOption = z.infer<typeof InitScriptSchemaOption>
 export type InitScriptOptions = z.infer<typeof InitScriptSchemaOptions>
 export type InitScriptPackageManager = z.infer<typeof InitScriptSchemaPackageManager>
 export type InitScriptRename = z.infer<typeof InitScriptSchemaRename>
+export type InitScriptRenameEntry = z.infer<typeof InitScriptSchemaRenameEntry>
 export type InitScriptSkills = z.infer<typeof InitScriptSchemaSkills>
 export type InitScriptVersions = z.infer<typeof InitScriptSchemaVersions>

--- a/test/init-script-options.test.ts
+++ b/test/init-script-options.test.ts
@@ -13,7 +13,7 @@ const options: InitScriptOptions = {
     group: 'engine',
     instructions: ['Start llama.cpp'],
     rename: {
-      __MODEL__: { paths: ['request.json'], to: 'local-model' },
+      __MODEL__: { in: ['request.json'], to: 'local-model' },
     },
   },
   ollama: {
@@ -21,7 +21,7 @@ const options: InitScriptOptions = {
     group: 'engine',
     instructions: ['Start Ollama'],
     rename: {
-      __MODEL__: { paths: ['request.json'], to: 'qwen3:0.6b' },
+      __MODEL__: { in: ['request.json'], to: 'qwen3:0.6b' },
     },
   },
 }

--- a/test/init-script-rename.test.ts
+++ b/test/init-script-rename.test.ts
@@ -68,7 +68,7 @@ describe('initScriptRename', () => {
     const fromNames = ['ExampleApp', 'EXAMPLE_APP', 'example-app', 'Example App', 'exampleApp']
     const rename = {
       'Example App': {
-        paths: ['app.json'],
+        in: ['app.json'],
         to: '{{name}}',
       },
     }
@@ -93,7 +93,7 @@ describe('initScriptRename', () => {
       await vi.importActual<typeof import('../src/utils/vendor/names')>('../src/utils/vendor/names')
     const rename = {
       'Example App': {
-        paths: ['app.json'],
+        in: ['app.json'],
         to: '{{name}}',
       },
     }
@@ -115,7 +115,7 @@ describe('initScriptRename', () => {
     const args = { ...baseArgs }
     const rename = {
       'inference-model': {
-        paths: ['request.json'],
+        in: ['request.json'],
         to: 'qwen3:0.6b',
       },
     }
@@ -164,7 +164,7 @@ describe('initScriptRename', () => {
     const args = { ...baseArgs, verbose: true }
     const rename = {
       example: {
-        paths: ['some/path/to/file'],
+        in: ['some/path/to/file'],
         to: '{{name}}Example',
       },
     }
@@ -184,6 +184,49 @@ describe('initScriptRename', () => {
     )
   })
 
+  it('should still replace using the deprecated `paths` and warn about it', async () => {
+    const args = { ...baseArgs }
+    const rename = {
+      example: {
+        paths: ['some/path/to/file'],
+        to: '{{name}}Example',
+      },
+    }
+    const exampleNames = ['Example']
+    const newNameExamples = ['test-projectExample']
+    vi.mocked(namesValues).mockImplementation((name) => (name === 'example' ? exampleNames : newNameExamples))
+    vi.mocked(ensureTargetPath).mockResolvedValue(true)
+
+    await initScriptRename(args, rename)
+
+    expect(searchAndReplace).toHaveBeenCalledWith(
+      expect.stringContaining('some/path/to/file'),
+      exampleNames,
+      newNameExamples,
+      args.dryRun,
+      args.verbose,
+    )
+    expect(log.warn).toHaveBeenCalledWith(
+      `initScriptRename: 'paths' is deprecated and is removed in the next major version, use 'in' instead: example`,
+    )
+  })
+
+  it('should not warn about `paths` when only `in` is used', async () => {
+    const args = { ...baseArgs }
+    const rename = {
+      example: {
+        in: ['some/path/to/file'],
+        to: '{{name}}Example',
+      },
+    }
+    vi.mocked(namesValues).mockReturnValue(['Example'])
+    vi.mocked(ensureTargetPath).mockResolvedValue(true)
+
+    await initScriptRename(args, rename)
+
+    expect(log.warn).not.toHaveBeenCalled()
+  })
+
   it('should log a message when verbose and no rename object is provided', async () => {
     const args: GetArgsResult = { ...baseArgs, verbose: true }
     await initScriptRename(args, undefined)
@@ -194,7 +237,7 @@ describe('initScriptRename', () => {
     const args = { ...baseArgs, verbose: true }
     const rename = {
       example: {
-        paths: ['some/path/to/file'],
+        in: ['some/path/to/file'],
         to: '{{name}}Example',
       },
     }
@@ -216,7 +259,7 @@ describe('initScriptRename', () => {
     const args = { ...baseArgs, verbose: true }
     const rename = {
       example: {
-        paths: ['nonexistent/path/to/file'],
+        in: ['nonexistent/path/to/file'],
         to: '{{name}}Example',
       },
     }

--- a/test/init-script-schema.test.ts
+++ b/test/init-script-schema.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { InitScriptSchema, InitScriptSchemaRename } from '../src/utils/init-script-schema'
+
+describe('InitScriptSchema - rename entries', () => {
+  const parseRename = (rename: unknown) => InitScriptSchema.parse({ rename }).rename
+
+  it('should accept `in`', () => {
+    const parsed = parseRename({ example: { in: ['some/path/to/file'], to: '{{name}}Example' } })
+
+    expect(parsed?.example.in).toEqual(['some/path/to/file'])
+    expect(parsed?.example.to).toBe('{{name}}Example')
+  })
+
+  it('should accept the deprecated `paths`', () => {
+    const parsed = parseRename({ example: { paths: ['some/path/to/file'], to: '{{name}}Example' } })
+
+    expect(parsed?.example.paths).toEqual(['some/path/to/file'])
+    expect(parsed?.example.in).toBeUndefined()
+  })
+
+  it('should accept an empty array', () => {
+    const parsed = parseRename({ example: { in: [], to: '{{name}}Example' } })
+
+    expect(parsed?.example.in).toEqual([])
+  })
+
+  it('should accept `in` and the deprecated `paths` in separate entries', () => {
+    const parsed = parseRename({
+      example1: { in: ['some/path/to/file1'], to: '{{name}}Example1' },
+      example2: { paths: ['some/path/to/file2'], to: '{{name}}Example2' },
+    })
+
+    expect(parsed?.example1.in).toEqual(['some/path/to/file1'])
+    expect(parsed?.example2.paths).toEqual(['some/path/to/file2'])
+  })
+
+  it('should reject an entry using both `in` and `paths`', () => {
+    const result = InitScriptSchemaRename.safeParse({
+      example: { in: ['path/from/in'], paths: ['path/from/paths'], to: '{{name}}Example' },
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error?.issues[0].message).toBe(
+      `Use either 'in' or 'paths', not both ('paths' is deprecated, use 'in')`,
+    )
+  })
+
+  it('should reject an entry with neither `in` nor `paths`', () => {
+    const result = InitScriptSchemaRename.safeParse({ example: { to: '{{name}}Example' } })
+
+    expect(result.success).toBe(false)
+    expect(result.error?.issues[0].message).toBe(`Missing 'in': list the paths to search for this rename`)
+  })
+
+  it('should reject an entry without `to`', () => {
+    expect(InitScriptSchemaRename.safeParse({ example: { in: ['some/path/to/file'] } }).success).toBe(false)
+  })
+})

--- a/test/root-exports-schemas.test.ts
+++ b/test/root-exports-schemas.test.ts
@@ -121,11 +121,11 @@ describe('package root schema exports', () => {
           description: 'Include mobile wallet adapter',
           group: 'mobile',
           instructions: ['pnpm run android'],
-          rename: { 'wallet-name': { paths: ['app'], to: 'my-wallet' } },
+          rename: { 'wallet-name': { in: ['app'], to: 'my-wallet' } },
         },
       },
       packageManager: 'pnpm',
-      rename: { 'anchor-project': { paths: ['anchor'], to: 'my-project' } },
+      rename: { 'anchor-project': { in: ['anchor'], to: 'my-project' } },
       skills: ['solana-dev'],
       versions: { anchor: '0.31.1', solana: '2.1.0' },
     }
@@ -151,7 +151,7 @@ describe('package root schema exports', () => {
     expectTypeOf<InitScriptInstructions>().toEqualTypeOf<string[]>()
     expectTypeOf<InitScriptSkills>().toEqualTypeOf<string[]>()
     expectTypeOf<InitScriptPackageManager>().toEqualTypeOf<'bun' | 'npm' | 'pnpm' | 'yarn'>()
-    expectTypeOf<InitScriptRename>().toEqualTypeOf<Record<string, { paths: string[]; to: string }>>()
+    expectTypeOf<InitScriptRename>().toEqualTypeOf<Record<string, { in?: string[]; paths?: string[]; to: string }>>()
     expectTypeOf<InitScriptOption>().toEqualTypeOf<{
       default?: boolean
       description?: string


### PR DESCRIPTION
Rename entries in the init script now take `in` instead of `paths`:

```jsonc
"rename": {
  "counter": {
    "in": ["anchor", "src"],
    "to": "{{name}}"
  }
}
```

Templates using `paths` keep working and log a deprecation warning. Support for `paths` is removed in the next major version, which gives the official templates time to migrate.

## Supersedes #211

This carries the commit from #211, authored by 0xObsidian, with the approach changed from an alias to a deprecation:

- `in` is canonical and `paths` is deprecated, rather than `paths` winning and `in` normalizing into it.
- An entry must set exactly one of the two. #211 made both optional, so an entry with neither parsed as an empty path list and silently renamed nothing — the current schema rejects that, and it stays rejected.
- No schema `.transform()`. It would have made the exported `InitScriptSchemaRename` a piped schema with differing input and output types, and normalizing at parse time destroys the information needed to warn about the deprecated spelling.

The other commit on #211 (`438a272`, error handling in the search-and-replace test) already landed via #210.

## Also in here

- `initScriptRenameEntries` resolves `in ?? paths` and warns once, naming the entries still on `paths`.
- README documents `in`, with `paths` marked deprecated.
- Updates the `InitScriptRename` type assertion added by #265.

## Release ordering

#265 exported these schemas but has not been released, so `InitScriptRename` currently changes shape without breaking anyone. Landing this before #250 keeps `{ paths: string[] }` from shipping and then immediately changing.
