### PR TITLE
fix: remove incompatible zod optional peer dependency

### DIFF
--- a/.changeset/zod-v4-schemas.md
+++ b/.changeset/zod-v4-schemas.md
@@ -2,4 +2,4 @@
 'create-solana-dapp': minor
 ---
 
-Migrate the init script and `package.json` schemas off the `zod/v3` compatibility import so every exported schema is a native Zod 4 schema, and declare `zod` as an optional peer dependency so consumers share a single Zod instance with the package.
+Migrate the init script and `package.json` schemas off the `zod/v3` compatibility import so every exported schema is a native Zod 4 schema.

--- a/package.json
+++ b/package.json
@@ -90,14 +90,6 @@
     "update-notifier": "7.3.1",
     "zod": "4.4.3"
   },
-  "peerDependencies": {
-    "zod": "^4"
-  },
-  "peerDependenciesMeta": {
-    "zod": {
-      "optional": true
-    }
-  },
   "contributors": [
     {
       "name": "Joe Caulfield",

--- a/test/package-manifest.test.ts
+++ b/test/package-manifest.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import packageJson from '../package.json'
+
+const dependencies: Record<string, string> = packageJson.dependencies
+const peerDependenciesMeta: Record<string, { optional?: boolean }> =
+  (packageJson as { peerDependenciesMeta?: Record<string, { optional?: boolean }> }).peerDependenciesMeta ?? {}
+
+describe('package manifest', () => {
+  it('should declare zod as a runtime dependency', () => {
+    // The CLI parses template catalogs and init scripts with zod, so it must resolve at runtime.
+    expect(dependencies.zod).toBeDefined()
+  })
+
+  it('should not declare any runtime dependency as an optional peer dependency', () => {
+    // pnpm skips installing optional peer dependencies entirely, even when the same package is
+    // listed in `dependencies`, which breaks `pnpm dlx create-solana-dapp` with a missing module.
+    const optionalPeers = Object.keys(peerDependenciesMeta).filter((name) => peerDependenciesMeta[name]?.optional)
+
+    expect(optionalPeers.filter((name) => name in dependencies)).toEqual([])
+  })
+})


### PR DESCRIPTION
pnpm resolves a package listed in both `dependencies` and `peerDependencies` as a peer, and skips installing it entirely when `peerDependenciesMeta` marks that peer optional. This left `zod` out of the install tree, so `pnpm dlx create-solana-dapp` failed with `Cannot find module 'zod'` while `npx` kept working through npm's hoisted layout.

Drop the `zod` peer declaration so it stays a plain runtime dependency, add a manifest test asserting no runtime dependency is declared as an optional peer, and trim the peer-dependency claim from the pending changeset.
